### PR TITLE
Raise exception when a template value is missing from the Jinja2 Context

### DIFF
--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -8,6 +8,7 @@ except ImportError:
 import pytest
 
 # local imports
+from shpkpr.template import UndefinedError
 from shpkpr.template import load_values_from_environment
 from shpkpr.template import render_json_template
 
@@ -80,4 +81,11 @@ def test_render_json_template_invalid_json_missing_value(monkeypatch):
     template_file = StringIO('{"type_of_muffin": {{ MUFFIN_TYPE }}}')
 
     with pytest.raises(ValueError):
+        render_json_template(template_file, **{"MUFFIN_TYPE": ""})
+
+
+def test_render_json_template_missing_value_raises(monkeypatch):
+    template_file = StringIO('{"type_of_muffin": "{{ MUFFIN_TYPE }}"}')
+
+    with pytest.raises(UndefinedError):
         render_json_template(template_file, **{})


### PR DESCRIPTION
Closes #28 

An exception is now raised when `shpkpr` attempts to render a template with an incomplete context (missing values).