### PR TITLE
Use mesos /master/redirect endpoint to resolve current Mesos leader URL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pytest-cov == 2.2.0
 pytest-flakes == 1.0.1
 pytest-mccabe == 0.1
 pytest-pep8 == 1.0.6
+responses == 0.5.0

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
         'jinja2==2.8',
         'marathon==0.7.2',
         'six>=1.10.0',
+        'requests>=2.0.0',
     ],
     entry_points='''
         [console_scripts]

--- a/tests/test_mesos.py
+++ b/tests/test_mesos.py
@@ -1,0 +1,59 @@
+# stdlib imports
+import re
+
+# third-party imports
+import responses
+
+# local imports
+from shpkpr.mesos import resolve_leader_url
+from shpkpr.mesos import MesosClient
+
+
+def _mock_valid_redirect():
+    responses.add(responses.HEAD,
+                  'http://master.example.com:5050/master/redirect',
+                  status=307,
+                  adding_headers={'Location': '//leader.example.com:5050'})
+    responses.add(responses.HEAD,
+                  re.compile(r'http://leader\.example\.com:5050/?'),
+                  status=200)
+
+
+@responses.activate
+def test_resolve_leader_valid_redirect():
+    _mock_valid_redirect()
+
+    leader_url = resolve_leader_url('http://master.example.com:5050')
+    assert leader_url == "http://leader.example.com:5050"
+
+
+@responses.activate
+def test_resolve_leader_valid_redirect_with_trailing_slash():
+    _mock_valid_redirect()
+
+    leader_url = resolve_leader_url('http://master.example.com:5050/')
+    assert leader_url == "http://leader.example.com:5050"
+
+
+@responses.activate
+def test_mesos_client_resolves_leader_url():
+    _mock_valid_redirect()
+
+    client = MesosClient('http://master.example.com:5050')
+    # testing private members of a class isn't usually encouraged, however, in
+    # this case the private members under test are the parts we've overridden
+    # from dcos.mesos.DCOSClient and we need to test our implementation.
+    assert client._leader_url is None
+    assert client._mesos_master_url == "http://leader.example.com:5050"
+    assert client._leader_url == "http://leader.example.com:5050"
+
+
+@responses.activate
+def test_mesos_client_caches_leader_url():
+    # reset all response mocks to ensure the mesos client will raise an
+    # exception if it tries to hit any remote URLs.
+    responses.reset()
+
+    client = MesosClient('http://master.example.com:5050')
+    client._leader_url = "http://leader.example.com:5050"
+    assert client._mesos_master_url == "http://leader.example.com:5050"


### PR DESCRIPTION
Closes #29 

This PR adds an extra step to resolve the current Mesos leader address before attempting to use the Mesos client. This means users can use the address of any Mesos master and `shpkpr` will just do the right thing™.