### PR TITLE
More robust exception handling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
         'dcos==0.2.0',
         'jinja2==2.8',
         'marathon==0.7.2',
+        'six>=1.10.0',
     ],
     entry_points='''
         [console_scripts]

--- a/shpkpr/commands/cmd_deploy.py
+++ b/shpkpr/commands/cmd_deploy.py
@@ -53,10 +53,7 @@ def cli(ctx, template_file, instances, mem, cpus, application_id):
     """
     # read and render deploy template using values from the environment
     values = load_values_from_environment(prefix=CONTEXT_SETTINGS['auto_envvar_prefix'])
-    try:
-        rendered_template = render_json_template(template_file, **values)
-    except ValueError as e:
-        raise click.ClickException("Invalid JSON: " + str(e))
+    rendered_template = render_json_template(template_file, **values)
     application = MarathonApp.from_json(rendered_template)
 
     # load existing config from marathon if available

--- a/shpkpr/template.py
+++ b/shpkpr/template.py
@@ -11,6 +11,16 @@ import jinja2
 from shpkpr import exceptions
 
 
+class InvalidJSONError(exceptions.ShpkprException):
+    """Raised when a template can be rendered successfully but does not parse
+    as valid JSON afterwards.
+    """
+    exit_code = 2
+
+    def format_message(self):
+        return 'Unable to parse rendered template as JSON, check variables'
+
+
 class UndefinedError(exceptions.ShpkprException):
     """Raised when a template contains a placeholder for a variable that
     wasn't included in the context dictionary passed in at render time.
@@ -38,6 +48,7 @@ def load_values_from_environment(prefix=""):
     return values
 
 
+@exceptions.rewrap(ValueError, InvalidJSONError)
 @exceptions.rewrap(jinja2.UndefinedError, UndefinedError)
 def render_json_template(template_file, **values):
     """Initialise a jinja2 template and render it with the passed-in values.

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,77 @@
+# third-party imports
+import pytest
+
+# local imports
+from shpkpr import exceptions
+
+
+@exceptions.rewrap(ValueError)
+def _this_doesnt_raise():
+    """Dummy func for testing the exceptions.rewrap decorator
+    """
+    return 'something'
+
+
+@exceptions.rewrap(ValueError)
+def _this_raises_a_key_error():
+    """Dummy func for testing the exceptions.rewrap decorator
+    """
+    return {}['non-existant-key']
+
+
+@exceptions.rewrap(ValueError)
+def _this_raises_a_value_error():
+    """Dummy func for testing the exceptions.rewrap decorator
+    """
+    return int("banana for scale")
+
+
+@exceptions.rewrap(ValueError, KeyError)
+def _this_also_raises_a_value_error():
+    """Dummy func for testing the exceptions.rewrap decorator
+    """
+    return int("I suggest you drop it, Mr. Data")
+
+
+class ExceptionRaiser(object):
+    """Dummy class for testing the exceptions.rewrap decorator
+    """
+
+    @exceptions.rewrap(KeyError)
+    def this_raises_a_key_error(self):
+        return {}['non-existant-key']
+
+    @exceptions.rewrap(ValueError)
+    def this_also_raises_a_key_error(self):
+        return {}['non-existant-key']
+
+
+def test_rewrap_func_doesnt_rewrap_uncaught_exception():
+    with pytest.raises(KeyError):
+        _this_raises_a_key_error()
+
+
+def test_rewrap_func_raises_correct_exception():
+    with pytest.raises(exceptions.ShpkprException):
+        _this_raises_a_value_error()
+
+
+def test_rewrap_func_raises_correct_exception_keyerror():
+    with pytest.raises(KeyError):
+        _this_also_raises_a_value_error()
+
+
+def test_rewrap_method_raises_correct_exception():
+    obj = ExceptionRaiser()
+    with pytest.raises(exceptions.ShpkprException):
+        obj.this_raises_a_key_error()
+
+
+def test_rewrap_method_doesnt_rewrap_uncaught_exception():
+    obj = ExceptionRaiser()
+    with pytest.raises(KeyError):
+        obj.this_also_raises_a_key_error()
+
+
+def test_decorated_func_returns_as_normal_when_nothing_is_raised():
+    assert _this_doesnt_raise() == 'something'

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -8,6 +8,7 @@ except ImportError:
 import pytest
 
 # local imports
+from shpkpr.template import InvalidJSONError
 from shpkpr.template import UndefinedError
 from shpkpr.template import load_values_from_environment
 from shpkpr.template import render_json_template
@@ -73,14 +74,14 @@ def test_render_json_template_valid(monkeypatch):
 def test_render_json_template_invalid_json_unquoted_string():
     template_file = StringIO('{"type_of_muffin": {{ MUFFIN_TYPE }}}')
 
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidJSONError):
         render_json_template(template_file, **{"MUFFIN_TYPE": "banana"})
 
 
 def test_render_json_template_invalid_json_missing_value(monkeypatch):
     template_file = StringIO('{"type_of_muffin": {{ MUFFIN_TYPE }}}')
 
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidJSONError):
         render_json_template(template_file, **{"MUFFIN_TYPE": ""})
 
 


### PR DESCRIPTION
This PR lays the groundwork for a more robust and comprehensive exception handling strategy within `shpkpr`.

Anywhere we expect an exception to be raised should use the new `@exceptions.rewrap` decorator and re-raise a subclass of `exceptions.ShpkprException` which will be handled nicely by Click and return a friendly error message to the user and exit with an appropriate status code.

Unhandled/uncaught exceptions will still `exit 1` and dump a full traceback to `stdout` as expected.