### PR TITLE
Template filters to enforce int/float

### DIFF
--- a/shpkpr/template.py
+++ b/shpkpr/template.py
@@ -9,6 +9,7 @@ import jinja2
 
 # local imports
 from shpkpr import exceptions
+from shpkpr import template_filters
 
 
 class InvalidJSONError(exceptions.ShpkprException):
@@ -64,6 +65,12 @@ def render_json_template(template_file, **values):
     ``values`` should be regular keyword arguments to the function which will
     be passed to the template at render time.
     """
-    template = jinja2.Template(template_file.read(), undefined=jinja2.StrictUndefined)
+    # build a new Jinja2 environment so we can inject some custom filters into
+    # the template we're rendering.
+    template_env = jinja2.Environment(undefined=jinja2.StrictUndefined)
+    template_env.filters['require_int'] = template_filters.require_int
+    template_env.filters['require_float'] = template_filters.require_float
+
+    template = template_env.from_string(template_file.read())
     rendered_template = template.render(**values)
     return json.loads(rendered_template)

--- a/shpkpr/template_filters.py
+++ b/shpkpr/template_filters.py
@@ -1,0 +1,72 @@
+# local imports
+from shpkpr import exceptions
+
+
+class IntegerRequired(exceptions.ShpkprException):
+    exit_code = 2
+
+
+class IntegerTooSmall(exceptions.ShpkprException):
+    exit_code = 2
+
+
+class IntegerTooLarge(exceptions.ShpkprException):
+    exit_code = 2
+
+
+@exceptions.rewrap(ValueError, IntegerRequired)
+def require_int(value, min=None, max=None):
+    """Jinja2 filter used to enforce an integer type in a template.
+
+    Accepts optional min/max constraints.
+
+    Usage:
+        {{ my_integer_value|require_int }}
+        {{ my_integer_value|require_int(min=0) }}
+        {{ my_integer_value|require_int(min=0, max=20) }}
+        {{ my_integer_value|require_int(max=20) }}
+    """
+    value = int(value)
+
+    # check the integer falls within the allowed range if set
+    if min is not None and value < min:
+        raise IntegerTooSmall("%d is smaller than the minimum allowed value of %d" % (value, min))
+    if max is not None and value > max:
+        raise IntegerTooLarge("%d is larger than the maximum allowed value of %d" % (value, max))
+
+    return value
+
+
+class FloatRequired(exceptions.ShpkprException):
+    exit_code = 2
+
+
+class FloatTooSmall(exceptions.ShpkprException):
+    exit_code = 2
+
+
+class FloatTooLarge(exceptions.ShpkprException):
+    exit_code = 2
+
+
+@exceptions.rewrap(ValueError, FloatRequired)
+def require_float(value, min=None, max=None):
+    """Jinja2 filter used to enforce an float type in a template.
+
+    Accepts optional min/max constraints.
+
+    Usage:
+        {{ my_float_value|require_float }}
+        {{ my_float_value|require_float(min=0) }}
+        {{ my_float_value|require_float(min=0, max=20) }}
+        {{ my_float_value|require_float(max=20) }}
+    """
+    value = float(value)
+
+    # check the float falls within the allowed range if set
+    if min is not None and value < min:
+        raise FloatTooSmall("%f is smaller than the minimum allowed value of %f" % (value, min))
+    if max is not None and value > max:
+        raise FloatTooLarge("%f is larger than the maximum allowed value of %f" % (value, max))
+
+    return value

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -12,6 +12,12 @@ from shpkpr.template import InvalidJSONError
 from shpkpr.template import UndefinedError
 from shpkpr.template import load_values_from_environment
 from shpkpr.template import render_json_template
+from shpkpr.template_filters import IntegerRequired
+from shpkpr.template_filters import IntegerTooLarge
+from shpkpr.template_filters import IntegerTooSmall
+from shpkpr.template_filters import FloatRequired
+from shpkpr.template_filters import FloatTooLarge
+from shpkpr.template_filters import FloatTooSmall
 
 
 def test_load_environment_vars_without_prefix(monkeypatch):
@@ -63,7 +69,7 @@ def test_load_environment_vars_with_prefix_with_trailing_underscore(monkeypatch)
     assert values['SHPKPR_APPLE_AND_BLACKCURRANT'] == 'crumble'
 
 
-def test_render_json_template_valid(monkeypatch):
+def test_render_json_template_valid():
     template_file = StringIO('{"type_of_muffin": "{{ MUFFIN_TYPE }}"}')
 
     rendered_template = render_json_template(template_file, **{"MUFFIN_TYPE": "banana"})
@@ -78,15 +84,99 @@ def test_render_json_template_invalid_json_unquoted_string():
         render_json_template(template_file, **{"MUFFIN_TYPE": "banana"})
 
 
-def test_render_json_template_invalid_json_missing_value(monkeypatch):
+def test_render_json_template_invalid_json_missing_value():
     template_file = StringIO('{"type_of_muffin": {{ MUFFIN_TYPE }}}')
 
     with pytest.raises(InvalidJSONError):
         render_json_template(template_file, **{"MUFFIN_TYPE": ""})
 
 
-def test_render_json_template_missing_value_raises(monkeypatch):
+def test_render_json_template_missing_value_raises():
     template_file = StringIO('{"type_of_muffin": "{{ MUFFIN_TYPE }}"}')
 
     with pytest.raises(UndefinedError):
         render_json_template(template_file, **{})
+
+
+def test_render_json_template_require_int():
+    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_int }}}')
+
+    rendered_template = render_json_template(template_file, **{"MUFFIN_COUNT": "1"})
+    assert rendered_template['muffin_count'] == 1
+
+
+def test_render_json_template_require_int_requires_int():
+    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_int }}}')
+
+    with pytest.raises(IntegerRequired):
+        render_json_template(template_file, **{"MUFFIN_COUNT": "one muffin"})
+
+
+def test_render_json_template_require_int_min_constraint():
+    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_int(min=50) }}}')
+
+    rendered_template = render_json_template(template_file, **{"MUFFIN_COUNT": "60"})
+    assert rendered_template['muffin_count'] == 60
+
+
+def test_render_json_template_require_int_min_constraint_raises():
+    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_int(min=50) }}}')
+
+    with pytest.raises(IntegerTooSmall):
+        render_json_template(template_file, **{"MUFFIN_COUNT": "40"})
+
+
+def test_render_json_template_require_int_max_constraint():
+    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_int(max=50) }}}')
+
+    rendered_template = render_json_template(template_file, **{"MUFFIN_COUNT": "-60"})
+    assert rendered_template['muffin_count'] == -60
+
+
+def test_render_json_template_require_int_max_constraint_raises():
+    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_int(max=50) }}}')
+
+    with pytest.raises(IntegerTooLarge):
+        render_json_template(template_file, **{"MUFFIN_COUNT": "60"})
+
+
+def test_render_json_template_require_float():
+    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_float }}}')
+
+    rendered_template = render_json_template(template_file, **{"MUFFIN_COUNT": "1.01"})
+    assert rendered_template['muffin_count'] == 1.01
+
+
+def test_render_json_template_require_float_requires_float():
+    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_float }}}')
+
+    with pytest.raises(FloatRequired):
+        render_json_template(template_file, **{"MUFFIN_COUNT": "one muffin"})
+
+
+def test_render_json_template_require_float_min_constraint():
+    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_float(min=50) }}}')
+
+    rendered_template = render_json_template(template_file, **{"MUFFIN_COUNT": "60"})
+    assert rendered_template['muffin_count'] == 60
+
+
+def test_render_json_template_require_float_min_constraint_raises():
+    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_float(min=50) }}}')
+
+    with pytest.raises(FloatTooSmall):
+        render_json_template(template_file, **{"MUFFIN_COUNT": "40"})
+
+
+def test_render_json_template_require_float_max_constraint():
+    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_float(max=50) }}}')
+
+    rendered_template = render_json_template(template_file, **{"MUFFIN_COUNT": "-60"})
+    assert rendered_template['muffin_count'] == -60
+
+
+def test_render_json_template_require_float_max_constraint_raises():
+    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_float(max=50) }}}')
+
+    with pytest.raises(FloatTooLarge):
+        render_json_template(template_file, **{"MUFFIN_COUNT": "60"})

--- a/tests/test_template_filters.py
+++ b/tests/test_template_filters.py
@@ -1,0 +1,55 @@
+# third-party imports
+import pytest
+
+# local imports
+from shpkpr import template_filters
+
+
+def test_require_int():
+    i = template_filters.require_int("1")
+    assert i == 1
+
+
+def test_require_int_in_range():
+    i = template_filters.require_int("1", min=0, max=5)
+    assert i == 1
+
+
+def test_require_int_not_an_int():
+    with pytest.raises(template_filters.IntegerRequired):
+        template_filters.require_int("abc")
+
+
+def test_require_int_too_low():
+    with pytest.raises(template_filters.IntegerTooSmall):
+        template_filters.require_int("-1", min=0)
+
+
+def test_require_int_too_high():
+    with pytest.raises(template_filters.IntegerTooLarge):
+        template_filters.require_int("1", max=0)
+
+
+def test_require_float():
+    i = template_filters.require_float("1")
+    assert i == 1
+
+
+def test_require_float_in_range():
+    i = template_filters.require_float("1", min=0, max=5)
+    assert i == 1
+
+
+def test_require_float_not_an_float():
+    with pytest.raises(template_filters.FloatRequired):
+        template_filters.require_float("abc")
+
+
+def test_require_float_too_low():
+    with pytest.raises(template_filters.FloatTooSmall):
+        template_filters.require_float("-1", min=0)
+
+
+def test_require_float_too_high():
+    with pytest.raises(template_filters.FloatTooLarge):
+        template_filters.require_float("1", max=0)


### PR DESCRIPTION
This PR adds `require_int` and `require_float` template filters that enforce number types in rendered templates.

**Note:** This branch was forked from `origin/more-robust-exception-handling` at [baad235](https://github.com/shopkeep/shpkpr/commit/baad235d050c2ad025f484746c67e461c0b97312) to make use of the new exception rewrapping features added in #33 and should **not be merged** until #33 is merged and this PR has been rebased on master.

[f608f25](https://github.com/shopkeep/shpkpr/commit/f608f25c0214a8ab43308a8c20cc7f2cdc7de830) is the only relevant commit for this PR (the rest are from #33).