### PR TITLE
Made prefix configurable when collecting template values from the environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist
 *.pyc
 *.pyo
 tests/__pycache__
+tests/commands/__pycache__
 .tox
 .coverage
 docs/_build

--- a/shpkpr/commands/cmd_deploy.py
+++ b/shpkpr/commands/cmd_deploy.py
@@ -47,12 +47,17 @@ def _update_property_with_defaults(application, existing_application, prop_name,
               type=click.File("r"),
               required=True,
               help="Path of the template to use for deployment.")
+@click.option('-e',
+              '--env_prefix',
+              'env_prefix',
+              default=CONTEXT_SETTINGS['auto_envvar_prefix'],
+              help="Path of the template to use for deployment.")
 @pass_context
-def cli(ctx, template_file, instances, mem, cpus, application_id):
+def cli(ctx, env_prefix, template_file, instances, mem, cpus, application_id):
     """Deploy application from template.
     """
     # read and render deploy template using values from the environment
-    values = load_values_from_environment(prefix=CONTEXT_SETTINGS['auto_envvar_prefix'])
+    values = load_values_from_environment(prefix=env_prefix)
     rendered_template = render_json_template(template_file, **values)
     application = MarathonApp.from_json(rendered_template)
 

--- a/tests/commands/test_cmd_deploy.py
+++ b/tests/commands/test_cmd_deploy.py
@@ -1,0 +1,22 @@
+# third-party imports
+from click.testing import CliRunner
+
+# local imports
+from shpkpr.cli import cli
+
+
+def test_no_args():
+    runner = CliRunner()
+    result = runner.invoke(cli, ['deploy'])
+
+    assert result.exit_code == 2
+    assert 'Usage:' in result.output
+
+
+def test_help():
+    runner = CliRunner()
+    result = runner.invoke(cli, ['deploy', '--help'])
+
+    assert result.exit_code == 0
+    assert 'Usage:' in result.output
+    assert 'Deploy application from template.' in result.output


### PR DESCRIPTION
Closes #26 

Allows the user to override the default `SHPKPR_` prefix when collecting values from the environment to be rendered in a template. This does not affect the way env vars are used as a substitute for CLI options, this only affects how variables are collected for template rendering purposes.

**Note:** We still don't have a good testing story for the commands themselves or the parameters attached to them. Full tests for these features will be added in a seperate upcoming PR.