### PR TITLE
Simplify deployment logic

### DIFF
--- a/shpkpr/commands/cmd_deploy.py
+++ b/shpkpr/commands/cmd_deploy.py
@@ -1,6 +1,5 @@
 # third-party imports
 import click
-from marathon.exceptions import NotFoundError
 from marathon.models import MarathonApp
 
 # local imports
@@ -12,35 +11,8 @@ from shpkpr.template import load_values_from_environment
 from shpkpr.template import render_json_template
 
 
-def _update_property_with_defaults(application, existing_application, prop_name, value, default):
-    """Update application property only if changed.
-
-    ``application`` is the application instance on which the property will be updated
-    ``existing_application`` is the application instance that is currently deployed to marathon (or None if not
-                             deployed)
-    ``prop_name`` is the name of the property on ``application`` that will be updated
-    ``value`` if not None will supercede values set anywhere else, this typically will come from the command line
-    ``default`` is a value that in the absence of any other source will be used to provide a sensible default
-    """
-    # set property value if specified
-    if value is not None:
-        setattr(application, prop_name, value)
-    # otherwise use the existing value from marathon
-    elif existing_application is not None and not getattr(application, prop_name):
-        setattr(application, prop_name, getattr(existing_application, prop_name))
-
-    # set a default value for instances if not specified
-    if getattr(application, prop_name) is None:
-        setattr(application, prop_name, default)
-
-    return application
-
-
 @click.command('deploy', short_help='Deploy application from template.', context_settings=CONTEXT_SETTINGS)
 @params.application
-@params.cpus
-@params.mem
-@params.instances
 @click.option('-t',
               '--template',
               'template_file',
@@ -53,7 +25,7 @@ def _update_property_with_defaults(application, existing_application, prop_name,
               default=CONTEXT_SETTINGS['auto_envvar_prefix'],
               help="Path of the template to use for deployment.")
 @pass_context
-def cli(ctx, env_prefix, template_file, instances, mem, cpus, application_id):
+def cli(ctx, env_prefix, template_file, application_id):
     """Deploy application from template.
     """
     # read and render deploy template using values from the environment
@@ -61,19 +33,10 @@ def cli(ctx, env_prefix, template_file, instances, mem, cpus, application_id):
     rendered_template = render_json_template(template_file, **values)
     application = MarathonApp.from_json(rendered_template)
 
-    # load existing config from marathon if available
-    try:
-        existing_application = ctx.marathon_client.get_application(application_id)
-    except NotFoundError:
-        existing_application = None
-
-    # override values from the command line
-    application = _update_property_with_defaults(application, existing_application, 'instances', instances, 1)
-    application = _update_property_with_defaults(application, existing_application, 'mem', mem, 512)
-    application = _update_property_with_defaults(application, existing_application, 'cpus', cpus, 0.1)
-
-    # set the application ID to the value specified on the command line (unconditionally)
-    application.id = application_id
+    # set the application ID to the value specified on the command line (if
+    # not already set, as marathon requires this)
+    if not application.id:
+        application.id = application_id
 
     deployment = ctx.marathon_client.deploy_application(application)
     try:

--- a/tests/test.json.tmpl
+++ b/tests/test.json.tmpl
@@ -7,7 +7,7 @@
     "type": "DOCKER",
     "docker": {
       "image": "{{DOCKER_REPOTAG}}",
-      "forcePullImage": true,
+      "forcePullImage": false,
       "network": "BRIDGE",
       "portMappings": [
         {
@@ -24,8 +24,8 @@
       "protocol": "HTTP",
       "portIndex": 0,
       "gracePeriodSeconds": 300,
-      "intervalSeconds": 20,
-      "timeoutSeconds": 10,
+      "intervalSeconds": 10,
+      "timeoutSeconds": 5,
       "maxConsecutiveFailures": 3
     }
   ],
@@ -39,8 +39,8 @@
     ]
   ],
   "upgradeStrategy": {
-      "minimumHealthCapacity": 0.7,
-      "maximumOverCapacity": 0.8
+      "minimumHealthCapacity": 1,
+      "maximumOverCapacity": 1
   },
   "labels": {
     "HAPROXY_MODE": "http",


### PR DESCRIPTION
Removed a bunch of unneccessary functionality from the deployment command. We were handling merges of cpu/instances/mem values in code before, but marathon handles this for us if the value simply isn't set.