### PR TITLE
Remove "DOMAIN" label from `show` output

### DIFF
--- a/shpkpr/commands/cmd_show.py
+++ b/shpkpr/commands/cmd_show.py
@@ -25,7 +25,6 @@ def _pretty_print(ctx, application):
     ctx.log("RAM:          %s", application.mem)
     ctx.log("Instances:    %s", application.instances)
     ctx.log("Docker Image: %s", application.container.docker.image)
-    ctx.log("Domain:       %s", application.labels.get("DOMAIN"))
     ctx.log("Version:      %s", application.version)
     ctx.log("Status:       %s", _task_status(application))
 


### PR DESCRIPTION
the DOMAIN label is a ShopKeep implementation detail and doesn't belong in shpkpr. Removing for now, and a future PR will address labels in a more generic way.