### PR TITLE
use cached_property decorator rather than managing caching manually

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     packages=['shpkpr', 'shpkpr.commands'],
     include_package_data=True,
     install_requires=[
+        'cached-property==1.3.0',
         'click==5.1',
         'dcos==0.2.0',
         'jinja2==2.8',

--- a/shpkpr/cli.py
+++ b/shpkpr/cli.py
@@ -20,8 +20,6 @@ class Context(object):
         self.buffer = sys.stdout
         self.marathon_url = None
         self.mesos_master_url = None
-        self._marathon_client = None
-        self._mesos_client = None
 
     @cached_property
     def marathon_client(self):

--- a/shpkpr/cli.py
+++ b/shpkpr/cli.py
@@ -4,6 +4,7 @@ import sys
 
 # third-party imports
 import click
+from cached_property import cached_property
 
 # local imports
 from shpkpr.marathon import MarathonClient
@@ -22,23 +23,19 @@ class Context(object):
         self._marathon_client = None
         self._mesos_client = None
 
-    @property
+    @cached_property
     def marathon_client(self):
         if not self.marathon_url:
             raise click.exceptions.UsageError("Missing option \"--marathon_url\".")
 
-        if self._marathon_client is None:
-            self._marathon_client = MarathonClient(self.marathon_url)
-        return self._marathon_client
+        return MarathonClient(self.marathon_url)
 
-    @property
+    @cached_property
     def mesos_client(self):
         if not self.mesos_master_url:
             raise click.exceptions.UsageError("Missing option \"--mesos_master_url\".")
 
-        if self._mesos_client is None:
-            self._mesos_client = MesosClient(self.mesos_master_url)
-        return self._mesos_client
+        return MesosClient(self.mesos_master_url)
 
     def log(self, msg, *args, **kwargs):
         """Logs a message to stdout."""

--- a/shpkpr/mesos.py
+++ b/shpkpr/mesos.py
@@ -4,6 +4,7 @@
 """
 # third-party imports
 import requests
+from cached_property import cached_property
 from dcos import mesos as dcos_mesos
 from dcos import util
 from dcos.errors import DCOSException
@@ -18,26 +19,20 @@ class MesosClient(dcos_mesos.DCOSClient):
         self._dcos_url = None
         self._timeout = 5
         self._master_url = mesos_master_url
-        self._leader_url = None
-        self._master = None
 
-    @property
+    @cached_property
     def _mesos_master(self):
         """Lazily load and cache a MesosMaster instance
         """
-        if self._master is None:
-            self._master = MesosMaster(self.get_master_state(), self)
-        return self._master
+        return MesosMaster(self.get_master_state(), self)
 
-    @property
+    @cached_property
     def _mesos_master_url(self):
         """Override _mesos_master_url to ensure that we always return a leader
         URL, regardless of whether the master URL passed in at init time is a
         leader or not.
         """
-        if self._leader_url is None:
-            self._leader_url = resolve_leader_url(self._master_url)
-        return self._leader_url
+        return resolve_leader_url(self._master_url)
 
     def get_tasks(self, fltr, completed=False):
         """Return tasks from mesos that match the given filter

--- a/tests/test_mesos.py
+++ b/tests/test_mesos.py
@@ -43,17 +43,18 @@ def test_mesos_client_resolves_leader_url():
     # testing private members of a class isn't usually encouraged, however, in
     # this case the private members under test are the parts we've overridden
     # from dcos.mesos.DCOSClient and we need to test our implementation.
-    assert client._leader_url is None
     assert client._mesos_master_url == "http://leader.example.com:5050"
-    assert client._leader_url == "http://leader.example.com:5050"
 
 
 @responses.activate
 def test_mesos_client_caches_leader_url():
+    _mock_valid_redirect()
+
+    client = MesosClient('http://master.example.com:5050')
+    assert client._mesos_master_url == "http://leader.example.com:5050"
+
     # reset all response mocks to ensure the mesos client will raise an
     # exception if it tries to hit any remote URLs.
     responses.reset()
 
-    client = MesosClient('http://master.example.com:5050')
-    client._leader_url = "http://leader.example.com:5050"
     assert client._mesos_master_url == "http://leader.example.com:5050"


### PR DESCRIPTION
This PR simplifies the handling of cached properties on classes with the third-party [cached-property](https://github.com/pydanny/cached-property) package. Handling manually is error prone and testing can be difficult. This package is well tested and stable.

**Note:** This PR ignores any properties in the `shpkpr.marathon` package as those will be covered in the upcoming refactor of our marathon package.