### PR TITLE
Added `_all_env` to all templates and new `filter_items` template filter

### DIFF
--- a/shpkpr/template.py
+++ b/shpkpr/template.py
@@ -68,9 +68,10 @@ def render_json_template(template_file, **values):
     # build a new Jinja2 environment so we can inject some custom filters into
     # the template we're rendering.
     template_env = jinja2.Environment(undefined=jinja2.StrictUndefined)
+    template_env.filters['filter_items'] = template_filters.filter_items
     template_env.filters['require_int'] = template_filters.require_int
     template_env.filters['require_float'] = template_filters.require_float
 
     template = template_env.from_string(template_file.read())
-    rendered_template = template.render(**values)
+    rendered_template = template.render(_all_env=values, **values)
     return json.loads(rendered_template)

--- a/shpkpr/template_filters.py
+++ b/shpkpr/template_filters.py
@@ -2,6 +2,28 @@
 from shpkpr import exceptions
 
 
+def filter_items(value, startswith=None, strip_prefix=False):
+    """Jinja2 filter used to filter a dictionary's keys by specifying a
+    required prefix.
+
+    Returns a list of key/value tuples.
+
+    Usage:
+        {{ my_dict|filter_items }}
+        {{ my_dict|filter_items("MY_PREFIX_") }}
+        {{ my_dict|filter_items("MY_PREFIX_", True) }}
+    """
+    if startswith is not None:
+        value = [x for x in value.items() if x[0].startswith(startswith)]
+    else:
+        value = value.items()
+
+    if startswith is not None and strip_prefix:
+        value = [(x[0].replace(startswith, "", 1), x[1]) for x in value]
+
+    return value
+
+
 class IntegerRequired(exceptions.ShpkprException):
     exit_code = 2
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -98,6 +98,29 @@ def test_render_json_template_missing_value_raises():
         render_json_template(template_file, **{})
 
 
+def test_render_json_template_all_env():
+    template_file = StringIO('''
+        {
+            "types_of_muffin": {
+                {% for k, v in _all_env|filter_items("MUFFIN_", True) %}
+                "{{ k.lower() }}": {{ v }}{% if loop.last == False %},{% endif %}
+                {% endfor %}
+            }
+        }
+    ''')
+
+    rendered_template = render_json_template(template_file, **{
+        "MUFFIN_BLUEBERRY": 4,
+        "MUFFIN_BANANA": 7,
+        "MUFFIN_CHOCOLATE": 12,
+        "DONUT_STRAWBERRY": 9,
+    })
+    assert "types_of_muffin" in rendered_template
+    assert rendered_template["types_of_muffin"]["blueberry"] == 4
+    assert rendered_template["types_of_muffin"]["banana"] == 7
+    assert rendered_template["types_of_muffin"]["chocolate"] == 12
+
+
 def test_render_json_template_require_int():
     template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_int }}}')
 

--- a/tests/test_template_filters.py
+++ b/tests/test_template_filters.py
@@ -5,6 +5,34 @@ import pytest
 from shpkpr import template_filters
 
 
+def test_filter_items():
+    values = template_filters.filter_items({"X": "a", "Y": "b", "Z": "c"})
+    assert ("X", "a") in values
+    assert ("Y", "b") in values
+    assert ("Z", "c") in values
+
+
+def test_filter_items_with_startswith():
+    values = template_filters.filter_items({"_X": "a", "_Y": "b", "Z": "c"}, startswith="_")
+    assert ("_X", "a") in values
+    assert ("_Y", "b") in values
+    assert ("Z", "c") not in values
+
+
+def test_filter_items_with_startswith_strip_prefix():
+    values = template_filters.filter_items({"_X": "a", "_Y": "b", "Z": "c"}, startswith="_", strip_prefix=True)
+    assert ("X", "a") in values
+    assert ("Y", "b") in values
+    assert ("Z", "c") not in values
+
+
+def test_filter_items_with_strip_prefix():
+    values = template_filters.filter_items({"_X": "a", "_Y": "b", "Z": "c"}, strip_prefix=True)
+    assert ("_X", "a") in values
+    assert ("_Y", "b") in values
+    assert ("Z", "c") in values
+
+
 def test_require_int():
     i = template_filters.require_int("1")
     assert i == 1


### PR DESCRIPTION
This PR adds a new `_all_env` dictionary to the template context when rendering. This allows easy iteration over or inspection of the values as a whole. In addition, a `filter_items` template filter has been added that allows easy filtering of dictionary items by a prefix on their keys. Together these additions make more complex/interesting template setups possible.

For example, the following is now possible inside a JSON template:

```
{
  "id": "my-application",
  "cmd": "sleep 60",
  "cpus": 0.1,
  "mem": 512,
  "instances": 1,
  "labels": {
    {% for k, v in _all_env|filter_items("LABEL_", True) %}
    "{{ k }}": {{ v }}{% if loop.last == False %},{% endif %}
    {% endfor %}
  }
}
```

And given the following environment variables (with the default prefix of `SHPKPR_`):

```bash
export SHPKPR_LABEL_DOMAIN=mydomain.com
export SHPKPR_LABEL_NODE_TYPE=webserver
export SHPKPR_LABEL_FAVORITE_ICECREAM_FLAVOR=vanilla
```

Will result in an output of:

```json
{
  "id": "my-application",
  "cmd": "sleep 60",
  "cpus": 0.1,
  "mem": 512,
  "instances": 1,
  "labels": {
    "DOMAIN": "mydomain.com",
    "NODE_TYPE": "webserver",
    "FAVORITE_ICECREAM_FLAVOR": "vanilla"
  }
}
```