### PR TITLE
Added initial documentation for deployment

### DIFF
--- a/docs/usage/cmd_config.rst
+++ b/docs/usage/cmd_config.rst
@@ -40,7 +40,7 @@ Required Configuration
 
     URL of the Marathon API to use, e.g. ``http://marathon.mydomain.com:8080``
 
-    * Evironment variable: ``SHPKPR_MARATHON_URL``
+    * Environment variable: ``SHPKPR_MARATHON_URL``
     * Command-line flag: ``--marathon_url``
 
 **Application ID:**
@@ -89,7 +89,7 @@ Required Configuration
 
     URL of the Marathon API to use, e.g. ``http://marathon.mydomain.com:8080``
 
-    * Evironment variable: ``SHPKPR_MARATHON_URL``
+    * Environment variable: ``SHPKPR_MARATHON_URL``
     * Command-line flag: ``--marathon_url``
 
 **Application ID:**
@@ -133,7 +133,7 @@ Required Configuration
 
     URL of the Marathon API to use, e.g. ``http://marathon.mydomain.com:8080``
 
-    * Evironment variable: ``SHPKPR_MARATHON_URL``
+    * Environment variable: ``SHPKPR_MARATHON_URL``
     * Command-line flag: ``--marathon_url``
 
 **Application ID:**

--- a/docs/usage/cmd_deploy.rst
+++ b/docs/usage/cmd_deploy.rst
@@ -1,0 +1,121 @@
+==================================
+Deploying a new application config
+==================================
+
+``shpkpr deploy`` allows you to deploy a new (or changes to an existing) application configuration by rendering and POSTing a JSON template to Marathon::
+
+    $ shpkpr deploy --help
+    Usage: shpkpr deploy [OPTIONS]
+
+      Deploy application from template.
+
+    Options:
+      -t, --template FILENAME  Path of the template to use for deployment.
+                               [required]
+      -e, --env_prefix TEXT    Prefix used to restrict environment vars used
+                               for templating.
+      --help                   Show this message and exit.
+
+
+Required Configuration
+^^^^^^^^^^^^^^^^^^^^^^
+
+**Marathon URL:**
+
+    URL of the Marathon API to use, e.g. ``http://marathon.mydomain.com:8080``
+
+    * Evironment variable: ``SHPKPR_MARATHON_URL``
+    * Command-line flag: ``--marathon_url``
+
+**JSON Template Path:**
+
+    Path of the JSON template to use for deployment, e.g. ``/some/path/to/a/template.json.tmpl`` or ``./my-template.json.tmpl``
+
+    * Environment variable: ``SHPKPR_TEMPLATE``
+    * Command-line flag: ``--template``
+
+Optional Configuration
+^^^^^^^^^^^^^^^^^^^^^^
+
+**Environment Variable Prefix:**
+
+    When reading variables from the environment to inject into the template at render time, only those variables which begin with the specified prefix are considered. The prefix is stripped from the variable names before injecting into the template context.
+
+    **Note:** The ``env_prefix`` in this case controls only the prefix used for collecting environment variables for templating purposes. The ``SHPKPR_`` prefix is **always** used for regular configuration as documented elsewhere.
+
+    * Environment variable: ``SHPKPR_ENV_PREFIX``
+    * Command-line flag: ``--env_prefix``
+    * Default: ``SHPKPR_``
+
+
+Examples
+^^^^^^^^
+
+::
+
+    $ cat deploy.json.tmpl
+    {
+      "id": "{{APPLICATION}}",
+      "cmd": "{{CMD}}",
+      "cpus": {{CPUS|require_float(min=0.0, max=2.0)}},
+      "mem": 512,
+      "instances": {{INSTANCES|require_int(min=1, max=16)}},
+      "labels": {
+        "DOMAIN": "{{LABEL_DOMAIN}}"
+      }
+    }
+
+    $ export SHPKPR_APPLICATION=my-app
+    $ export SHPKPR_CPUS=0.1
+    $ export SHPKPR_INSTANCES=2
+    $ export SHPKPR_CMD="sleep 60"
+    $ export SHPKPR_LABEL_DOMAIN=mydomain.com
+
+    $ shpkpr deploy -t deploy.json.tmpl
+
+    # Would result in the following output sent to Marathon
+    # {
+    #   "id": "my-app",
+    #   "cmd": "sleep 60",
+    #   "cpus": 0.1,
+    #   "mem": 512,
+    #   "instances": 2,
+    #   "labels": {
+    #     "DOMAIN": "mydomain.com"
+    #   }
+    # }
+::
+
+    $ cat deploy.json.tmpl
+    {
+      "id": "my-application",
+      "cmd": "sleep 60",
+      "cpus": 0.1,
+      "mem": 512,
+      "instances": 1,
+      "labels": {
+        {% for k, v in _all_env|filter_items("LABEL_", True) %}
+        "{{ k }}": "{{ v }}"{% if loop.last == False %},{% endif %}
+        {% endfor %}
+      }
+    }
+
+    $ export LABEL_DOMAIN=mydomain.com
+    $ export LABEL_NODE_TYPE=webserver
+    $ export LABEL_FAVORITE_ICECREAM_FLAVOR=vanilla
+
+    $ shpkpr deploy -t deploy.json.tmpl -e ""
+
+    # Would result in the following output sent to Marathon
+    # {
+    #   "id": "my-application",
+    #   "cmd": "sleep 60",
+    #   "cpus": 0.1,
+    #   "mem": 512,
+    #   "instances": 1,
+    #   "labels": {
+    #     "DOMAIN": "mydomain.com",
+    #     "NODE_TYPE": "webserver",
+    #     "FAVORITE_ICECREAM_FLAVOR": "vanilla"
+    #   }
+    # }

--- a/docs/usage/cmd_deploy.rst
+++ b/docs/usage/cmd_deploy.rst
@@ -24,7 +24,7 @@ Required Configuration
 
     URL of the Marathon API to use, e.g. ``http://marathon.mydomain.com:8080``
 
-    * Evironment variable: ``SHPKPR_MARATHON_URL``
+    * Environment variable: ``SHPKPR_MARATHON_URL``
     * Command-line flag: ``--marathon_url``
 
 **JSON Template Path:**

--- a/docs/usage/cmd_list.rst
+++ b/docs/usage/cmd_list.rst
@@ -19,7 +19,7 @@ Required Configuration
 
     URL of the Marathon API to use, e.g. ``http://marathon.mydomain.com:8080``
 
-    * Evironment variable: ``SHPKPR_MARATHON_URL``
+    * Environment variable: ``SHPKPR_MARATHON_URL``
     * Command-line flag: ``--marathon_url``
 
 Examples

--- a/docs/usage/cmd_logs.rst
+++ b/docs/usage/cmd_logs.rst
@@ -24,7 +24,7 @@ Required Configuration
 
     URL of the Mesos master to connect to to retrieve logs, e.g. ``http://mesos-master.mydomain.com:5050``
 
-    * Evironment variable: ``SHPKPR_MESOS_MASTER_URL``
+    * Environment variable: ``SHPKPR_MESOS_MASTER_URL``
     * Command-line flag: ``--mesos_master_url``
 
 **Application ID:**
@@ -41,7 +41,7 @@ Optional Configuration
 
     The number of log lines to show in the output (per instance), e.g. ``5``
 
-    * Evironment variable: ``SHPKPR_LINES``
+    * Environment variable: ``SHPKPR_LINES``
     * Command-line flag: ``--lines``
     * Default: ``10``
 

--- a/docs/usage/cmd_scale.rst
+++ b/docs/usage/cmd_scale.rst
@@ -25,7 +25,7 @@ Required Configuration
 
     URL of the Marathon API to use, e.g. ``http://marathon.mydomain.com:8080``
 
-    * Evironment variable: ``SHPKPR_MARATHON_URL``
+    * Environment variable: ``SHPKPR_MARATHON_URL``
     * Command-line flag: ``--marathon_url``
 
 **Application ID:**
@@ -42,7 +42,7 @@ Optional Configuration
 
     The number of CPU`s this application needs per instance. This number does not have to be integer, but can be a fraction. e.g. ``0.5``
 
-    * Evironment variable: ``SHPKPR_CPUS``
+    * Environment variable: ``SHPKPR_CPUS``
     * Command-line flag: ``--cpus``
 
 **Memory/RAM:**

--- a/docs/usage/cmd_show.rst
+++ b/docs/usage/cmd_show.rst
@@ -20,7 +20,7 @@ Required Configuration
 
     URL of the Marathon API to use, e.g. ``http://marathon.mydomain.com:8080``
 
-    * Evironment variable: ``SHPKPR_MARATHON_URL``
+    * Environment variable: ``SHPKPR_MARATHON_URL``
     * Command-line flag: ``--marathon_url``
 
 **Application ID:**

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -33,4 +33,5 @@ For more detailed usage instructions use the sections linked below:
    cmd_show
    cmd_config
    cmd_scale
+   cmd_deploy
    cmd_logs

--- a/shpkpr/commands/cmd_deploy.py
+++ b/shpkpr/commands/cmd_deploy.py
@@ -23,7 +23,7 @@ from shpkpr.template import render_json_template
               '--env_prefix',
               'env_prefix',
               default=CONTEXT_SETTINGS['auto_envvar_prefix'],
-              help="Path of the template to use for deployment.")
+              help="Prefix used to restrict environment vars used for templating.")
 @pass_context
 def cli(ctx, env_prefix, template_file, application_id):
     """Deploy application from template.


### PR DESCRIPTION
This PR adds initial documentation for `shpkpr deploy`. This documentation reflects the state of `deploy` after #41 and #42 have been merged and should not be merged until both of those PRs have been approved and are in master.

Closes #32