### PR TITLE
Strip unvalidated properties from JSON returned by Marathon

### DIFF
--- a/shpkpr/marathon/client.py
+++ b/shpkpr/marathon/client.py
@@ -31,21 +31,20 @@ class MarathonClient(object):
         request = getattr(requests, method.lower())
         return request(self._build_url(path), **kwargs)
 
-    @property
-    def embed_params(self):
+    def embed_params(self, entity_type):
         return [
-            "app.tasks",
-            "app.counts",
-            "app.deployments",
-            "app.lastTaskFailure",
-            "app.taskStats",
+            "{0}.tasks".format(entity_type),
+            "{0}.counts".format(entity_type),
+            "{0}.deployments".format(entity_type),
+            "{0}.lastTaskFailure".format(entity_type),
+            "{0}.taskStats".format(entity_type),
         ]
 
     def get_application(self, application_id):
         """Returns detailed information for a single application.
         """
         path = "/v2/apps/" + application_id
-        params = {"embed": self.embed_params}
+        params = {"embed": self.embed_params("app")}
         response = self._make_request('GET', path, params=params)
 
         if response.status_code == 200:
@@ -63,7 +62,7 @@ class MarathonClient(object):
         """Return a list of all applications currently deployed to marathon.
         """
         path = "/v2/apps"
-        params = {"embed": self.embed_params}
+        params = {"embed": self.embed_params("apps")}
         response = self._make_request('GET', path, params=params)
 
         if response.status_code == 200:

--- a/shpkpr/marathon/client.py
+++ b/shpkpr/marathon/client.py
@@ -49,8 +49,7 @@ class MarathonClient(object):
 
         if response.status_code == 200:
             application = response.json()['app']
-            validate_app(application)
-            return application
+            return validate_app(application)
 
         # raise an appropriate error if something went wrong
         if response.status_code == 404:
@@ -67,9 +66,7 @@ class MarathonClient(object):
 
         if response.status_code == 200:
             applications = response.json()['apps']
-            for application in applications:
-                validate_app(application)
-            return applications
+            return [validate_app(app) for app in applications]
 
         raise ClientError("Unknown Marathon error: %s\n\n%s" % (response.status_code, response.text))
 
@@ -82,7 +79,7 @@ class MarathonClient(object):
     def deploy_application(self, application, force=False):
         """Deploys the given application to Marathon.
         """
-        validate_deploy(application)
+        application = validate_deploy(application)
 
         path = "/v2/apps/" + application['id']
         params = {"force": force}

--- a/shpkpr/marathon/schema/app.json
+++ b/shpkpr/marathon/schema/app.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema#",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "definitions": {
     "pathType": {
       "pattern": "^(\\/?((\\.{2})|([a-z0-9][a-z0-9\\-.]*[a-z0-9]+)|([a-z0-9]*))($|\\/))+$",
@@ -14,16 +14,6 @@
       },
       "type": ["array", "null"],
       "description": "An array of strings that represents an alternative mode of specifying the command to run. This was motivated by safe usage of containerizer features like a custom Docker ENTRYPOINT. This args field may be used in place of cmd even when using the default command executor. This change mirrors API and semantics changes in the Mesos CommandInfo protobuf message starting with version `0.20.0`.  Either `cmd` or `args` must be supplied. It is invalid to supply both `cmd` and `args` in the same app."
-    },
-    "backoffFactor": {
-      "minimum": 1.0,
-      "type": "number",
-      "description": "Configures exponential backoff behavior when launching potentially sick apps. This prevents sandboxes associated with consecutively failing tasks from filling up the hard disk on Mesos slaves. The backoff period is multiplied by the factor for each consecutive failure until it reaches maxLaunchDelaySeconds. This applies also to tasks that are killed due to failing too many health checks."
-    },
-    "backoffSeconds": {
-      "description": "Configures exponential backoff behavior when launching potentially sick apps. This prevents sandboxes associated with consecutively failing tasks from filling up the hard disk on Mesos slaves. The backoff period is multiplied by the factor for each consecutive failure until it reaches maxLaunchDelaySeconds. This applies also to tasks that are killed due to failing too many health checks.",
-      "minimum": 0,
-      "type": "integer"
     },
     "cmd": {
       "description": "The command that is executed.  This value is wrapped by Mesos via `/bin/sh -c ${app.cmd}`.  Either `cmd` or `args` must be supplied. It is invalid to supply both `cmd` and `args` in the same app.",
@@ -132,12 +122,6 @@
       "minimum": 0,
       "type": "number"
     },
-    "dependencies": {
-      "items": {
-        "$ref": "#/definitions/pathType"
-      },
-      "type": "array"
-    },
     "deployments": {
       "items": {
         "additionalProperties": false,
@@ -150,10 +134,6 @@
       },
       "type": "array"
     },
-    "disk": {
-      "minimum": 0,
-      "type": "number"
-    },
     "env": {
       "patternProperties": {
         ".*": {
@@ -161,59 +141,6 @@
         }
       },
       "type": "object"
-    },
-    "executor": {
-      "pattern": "^(|\\/\\/cmd|\\/?[^\\/]+(\\/[^\\/]+)*)$",
-      "type": "string"
-    },
-    "healthChecks": {
-      "items": {
-        "additionalProperties": false,
-        "properties": {
-          "command": {
-            "type": "object",
-            "items": {
-              "additionalProperties": false,
-              "properties": {
-                "value": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "gracePeriodSeconds": {
-            "minimum": 0,
-            "type": "integer"
-          },
-          "ignoreHttp1xx": {
-            "type": "boolean"
-          },
-          "intervalSeconds": {
-            "minimum": 0,
-            "type": "integer"
-          },
-          "maxConsecutiveFailures": {
-            "minimum": 0,
-            "type": "integer"
-          },
-          "path": {
-            "type": "string"
-          },
-          "portIndex": {
-            "minimum": 0,
-            "type": "integer"
-          },
-          "protocol": {
-            "type": "string"
-          },
-          "timeoutSeconds": {
-            "minimum": 0,
-            "type": "integer"
-          }
-        },
-        "type": "object"
-      },
-      "type": "array"
     },
     "id": {
       "$ref": "#/definitions/pathType",
@@ -223,141 +150,7 @@
       "minimum": 0,
       "type": "integer"
     },
-    "labels": {
-      "additionalProperties": {
-        "type": "string"
-      },
-      "type": "object"
-    },
-    "lastTaskFailure": {
-      "additionalProperties": false,
-      "properties": {
-        "appId": {
-          "type": "string"
-        },
-        "host": {
-          "type": "string"
-        },
-        "message": {
-          "type": "string"
-        },
-        "state": {
-          "type": "string"
-        },
-        "taskId": {
-          "type": "string"
-        },
-        "timestamp": {
-          "type": "string"
-        },
-        "version": {
-          "type": "string"
-        }
-      },
-      "type": ["object", "null"]
-    },
-    "maxLaunchDelaySeconds": {
-      "minimum": 0,
-      "type": "integer"
-    },
     "mem": {
-      "minimum": 0,
-      "type": "number"
-    },
-    "ports": {
-      "items": {
-        "maximum": 65535,
-        "minimum": 0,
-        "type": "integer"
-      },
-      "type": "array",
-      "uniqueItems": true
-    },
-    "requirePorts": {
-      "type": "boolean"
-    },
-    "storeUrls": {
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
-    },
-    "tasks": {
-      "items": {
-        "additionalProperties": false,
-        "properties": {
-          "command": {
-            "type": "object",
-            "items": {
-              "additionalProperties": false,
-              "properties": {
-                "value": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "appId": {
-            "type": "string"
-          },
-
-          "healthCheckResults": {
-            "items": {
-              "additionalProperties": false,
-              "properties": {
-                "alive": {
-                  "type": "boolean"
-                },
-                "consecutiveFailures": {
-                  "type": "number"
-                },
-                "firstSuccess": {
-                  "type": ["string", "null"]
-                },
-                "lastFailure": {
-                  "type": ["string", "null"]
-                },
-                "lastSuccess": {
-                  "type": ["string", "null"]
-                },
-                "taskId": {
-                  "type": "string"
-                }
-              },
-              "type": ["object", "null"]
-            },
-            "type": "array"
-          },
-          "host": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          },
-          "ports": {
-            "items": {
-              "maximum": 65535,
-              "minimum": 0,
-              "type": "integer"
-            },
-            "type": "array",
-            "uniqueItems": true
-          },
-          "stagedAt": {
-            "type": ["string", "null"]
-          },
-          "startedAt": {
-            "type": ["string", "null"]
-          },
-          "version": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "type": "array"
-    },
-    "tasksStaged": {
       "minimum": 0,
       "type": "number"
     },
@@ -365,38 +158,9 @@
       "minimum": 0,
       "type": "number"
     },
-    "tasksHealthy": {
-      "minimum": 0,
-      "type": "number"
-    },
     "tasksUnhealthy": {
       "minimum": 0,
       "type": "number"
-    },
-    "upgradeStrategy": {
-      "additionalProperties": false,
-      "properties": {
-        "maximumOverCapacity": {
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "type": "number"
-        },
-        "minimumHealthCapacity": {
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "type": "number"
-        }
-      },
-      "type": "object"
-    },
-    "uris": {
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
-    },
-    "user": {
-      "type": ["string", "null"]
     },
     "version": {
       "format": "date-time",
@@ -405,34 +169,17 @@
   },
   "required": [
     "args",
-    "backoffFactor",
-    "backoffSeconds",
     "cmd",
     "constraints",
     "container",
     "cpus",
-    "dependencies",
     "deployments",
-    "disk",
     "env",
-    "executor",
-    "healthChecks",
     "id",
     "instances",
-    "labels",
-    "maxLaunchDelaySeconds",
     "mem",
-    "ports",
-    "requirePorts",
-    "storeUrls",
-    "tasks",
-    "tasksStaged",
     "tasksRunning",
-    "tasksHealthy",
     "tasksUnhealthy",
-    "upgradeStrategy",
-    "uris",
-    "user",
     "version"
   ],
   "type": "object"

--- a/shpkpr/marathon/schema/app.json
+++ b/shpkpr/marathon/schema/app.json
@@ -12,7 +12,7 @@
       "items": {
         "type": ["string", "null"]
       },
-      "type": "array",
+      "type": ["array", "null"],
       "description": "An array of strings that represents an alternative mode of specifying the command to run. This was motivated by safe usage of containerizer features like a custom Docker ENTRYPOINT. This args field may be used in place of cmd even when using the default command executor. This change mirrors API and semantics changes in the Mesos CommandInfo protobuf message starting with version `0.20.0`.  Either `cmd` or `args` must be supplied. It is invalid to supply both `cmd` and `args` in the same app."
     },
     "backoffFactor": {
@@ -324,7 +324,7 @@
                   "type": "string"
                 }
               },
-              "type": "object"
+              "type": ["object", "null"]
             },
             "type": "array"
           },
@@ -344,10 +344,10 @@
             "uniqueItems": true
           },
           "stagedAt": {
-            "type": "string"
+            "type": ["string", "null"]
           },
           "startedAt": {
-            "type": "string"
+            "type": ["string", "null"]
           },
           "version": {
             "type": "string"
@@ -420,7 +420,6 @@
     "id",
     "instances",
     "labels",
-    "lastTaskFailure",
     "maxLaunchDelaySeconds",
     "mem",
     "ports",

--- a/shpkpr/marathon/validate.py
+++ b/shpkpr/marathon/validate.py
@@ -10,11 +10,19 @@ import jsonschema
 from shpkpr import exceptions
 
 
-def load_schema(name):
-    """Path to the default schema used to validate application definitions
-    before sending to marathon.
+def schema_path(name):
+    """Returns a path for one of the schema files distributed with shpkpr
     """
-    return os.path.join(os.path.dirname(os.path.realpath(__file__)), "schema", "%s.json" % name)
+    this_directory = os.path.dirname(os.path.realpath(__file__))
+    return os.path.join(this_directory, "schema", "%s.json" % name)
+
+
+def read_schema_from_file(path):
+    """Read a JSON schema from disk and transform into a dict
+    """
+    with open(path, 'r') as f:
+        schema = f.read()
+    return json.loads(schema)
 
 
 class ValidationError(exceptions.ShpkprException):
@@ -24,34 +32,23 @@ class ValidationError(exceptions.ShpkprException):
         return 'Unable to validate application: %s' % self.message
 
 
-class SchemaValidator(object):
+class Schema(object):
 
-    def __init__(self, schema_path, strip=False):
-        self._schema = self._read_schema_from_file(schema_path)
-        self._strip = strip
+    def __init__(self, schema):
+        self._schema = schema
 
     @exceptions.rewrap(jsonschema.ValidationError, ValidationError)
-    def __call__(self, application):
+    def validate(self, application):
+        """Validates the given application using the JSON schema
+        """
         jsonschema.validate(application, self._schema)
-        if not self._strip:
-            return application
-        return self.strip(application)
-
-    def _read_schema_from_file(self, path):
-        with open(path, 'r') as f:
-            schema = f.read()
-        return json.loads(schema)
 
     def strip(self, application):
         """Removes any top level properties from the application dictionary
-        that haven't been validated by the schema. This helps prevent the
+        that aren't defined by the schema. This helps prevent the
         unintended use of unvalidated properties.
         """
         stripped_app = {}
-        for key in self._schema['required']:
+        for key in self._schema.get('required', []):
             stripped_app[key] = copy.deepcopy(application[key])
         return stripped_app
-
-
-validate_app = SchemaValidator(load_schema("app"), strip=True)
-validate_deploy = SchemaValidator(load_schema("deploy"))

--- a/tests/marathon/test_client.py
+++ b/tests/marathon/test_client.py
@@ -29,7 +29,7 @@ def test_get_application():
     client = MarathonClient("http://marathon.somedomain.com:8080")
     application = client.get_application('test-app')
     assert application['id'] == "/test-app"
-    assert application['tasks'][1]['host'] == '10.210.51.111'
+    assert application['cmd'] is None
 
 
 @responses.activate


### PR DESCRIPTION
This PR tightens up the schema validation for data received from Marathon. We now only validate the fields we actually use and all others are stripped from the dictionary before being returned by `MarathonClient`. This ensures that we keep our marathon interface as small as possible to reduce risk that it'll change underneath us.

In future, if a developer needs access to an additional field/property they should add it to the JSON schema and if validated correctly will then be available to the application for use.