### PR TITLE
Added missing metadata and test setup to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,45 @@
+# stdlib imports
+import sys
 from setuptools import setup
+from setuptools.command.test import test as TestCommand
+
+
+with open('README.rst') as readme_file:
+    readme = readme_file.read()
+
+
+class Tox(TestCommand):
+
+    user_options = [('tox-args=', 'a', "Arguments to pass to tox")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.tox_args = None
+
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        # import here, because outside the eggs aren't loaded
+        import tox
+        import shlex
+        args = self.tox_args
+        if args:
+            args = shlex.split(self.tox_args)
+        errno = tox.cmdline(args=args)
+        sys.exit(errno)
+
 
 setup(
     name='shpkpr',
     version='0.1',
+    description='shpkpr is a command-line tool designed to manage applications running on Marathon',
+    long_description=readme,
+    author='ShopKeep.com Inc.',
+    author_email='developers@shopkeep.com',
+    url='https://github.com/shopkeep/shpkpr',
     packages=['shpkpr', 'shpkpr.commands'],
     include_package_data=True,
     install_requires=[
@@ -13,8 +50,26 @@ setup(
         'six>=1.10.0',
         'requests>=2.0.0',
     ],
+    license='MIT',
+    zip_safe=False,
+    keywords='shpkpr mesos marathon',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+    ],
     entry_points='''
         [console_scripts]
         shpkpr=shpkpr.cli:cli
     ''',
+    tests_require=['tox'],
+    cmdclass={'test': Tox},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, pypy, integration
+envlist = py27, py33, py34, py35, pypy
 
 [pytest]
 pep8maxlinelength = 119


### PR DESCRIPTION
This PR adds missing metadata to `setup.py` to prepare for release to PyPI in future. It also adds adds test integration so tests can now be run with `tox` using `python setup.py test` (yay for standards!).

To run tests for a specific environment, the user can pass additional arguments to `tox` like so:

- `python setup.py test -a "-e py27"`
- `python setup.py test --tox-args="-e integration"`

Closes #45 