### PR TITLE
Sleep before deploy check

### DIFF
--- a/shpkpr/marathon/deployment.py
+++ b/shpkpr/marathon/deployment.py
@@ -64,6 +64,9 @@ class MarathonDeployment(object):
         _started = datetime.datetime.utcnow()
 
         while True:
+
+            time.sleep(check_interval_secs)
+
             # check if the deployment has completed, if it has we return True
             if self.check():
                 return True
@@ -72,5 +75,3 @@ class MarathonDeployment(object):
             delta = datetime.datetime.utcnow() - _started
             if delta.total_seconds() > timeout:
                 raise DeploymentFailed('Timed out: %d seconds' % timeout)
-
-            time.sleep(check_interval_secs)

--- a/tests/marathon/test_client.py
+++ b/tests/marathon/test_client.py
@@ -91,7 +91,7 @@ def test_deploy_application(mock_deployment_check):
 
     client = MarathonClient("http://marathon.somedomain.com:8080")
     deployment = client.deploy_application({"id": "test-app"})
-    assert deployment.wait() == True
+    assert deployment.wait(check_interval_secs=0.1)
 
 
 @responses.activate

--- a/tests/marathon/test_deployment.py
+++ b/tests/marathon/test_deployment.py
@@ -33,7 +33,7 @@ def test_deployment_wait_with_timeout(mock_deployment_check):
     deployment = MarathonDeployment(client, "", '1234', '2')
     with pytest.raises(DeploymentFailed):
         deployment.wait(timeout=1, check_interval_secs=0.5)
-    assert mock_deployment_check.call_count == 3
+    assert mock_deployment_check.call_count == 2
 
 
 @mock.patch('shpkpr.marathon.MarathonClient.get_application')


### PR DESCRIPTION
This PR moves the sleep in `deployment.wait()` to before the first check. This ensures that shpkpr doesn't immediately check for a new deployment as marathon sometimes takes a second or two to acknowledge the deploy.