### PR TITLE
Forced deployments

### DIFF
--- a/docs/usage/cmd_config.rst
+++ b/docs/usage/cmd_config.rst
@@ -99,6 +99,15 @@ Required Configuration
     * Environment variable: ``SHPKPR_APPLICATION``
     * Command-line flag: ``--application``
 
+Optional Configuration
+^^^^^^^^^^^^^^^^^^^^^^
+
+**Force:**
+
+    Using the force flag allows the user to initiate a configuration change even if another deployment is currently in progress. This option should only be used in the case of a previous failed deployment as it *may* leave the app in an inconsistent state if anything goes wrong.
+
+    * Command-line flag: ``--force``
+
 Examples
 ^^^^^^^^
 
@@ -142,6 +151,15 @@ Required Configuration
 
     * Environment variable: ``SHPKPR_APPLICATION``
     * Command-line flag: ``--application``
+
+Optional Configuration
+^^^^^^^^^^^^^^^^^^^^^^
+
+**Force:**
+
+    Using the force flag allows the user to initiate a configuration change even if another deployment is currently in progress. This option should only be used in the case of a previous failed deployment as it *may* leave the app in an inconsistent state if anything goes wrong.
+
+    * Command-line flag: ``--force``
 
 Examples
 ^^^^^^^^

--- a/docs/usage/cmd_deploy.rst
+++ b/docs/usage/cmd_deploy.rst
@@ -37,6 +37,12 @@ Required Configuration
 Optional Configuration
 ^^^^^^^^^^^^^^^^^^^^^^
 
+**Force:**
+
+    Using the force flag allows the user to initiate a deployment even if another deployment is currently in progress. This option should only be used in the case of a previous failed deployment as it *may* leave the app in an inconsistent state if anything goes wrong.
+
+    * Command-line flag: ``--force``
+
 **Environment Variable Prefix:**
 
     When reading variables from the environment to inject into the template at render time, only those variables which begin with the specified prefix are considered. The prefix is stripped from the variable names before injecting into the template context.

--- a/docs/usage/cmd_scale.rst
+++ b/docs/usage/cmd_scale.rst
@@ -59,6 +59,12 @@ Optional Configuration
     * Environment variable: ``SHPKPR_INSTANCES``
     * Command-line flag: ``--instances``
 
+**Force:**
+
+    Using the force flag allows the user to initiate scaling even if another deployment is currently in progress. This option should only be used in the case of a previous failed deployment as it *may* leave the app in an inconsistent state if anything goes wrong.
+
+    * Command-line flag: ``--force``
+
 Examples
 ^^^^^^^^
 

--- a/shpkpr/cli/options.py
+++ b/shpkpr/cli/options.py
@@ -52,6 +52,13 @@ follow = click.option(
 )
 
 
+force = click.option(
+    '--force',
+    is_flag=True,
+    help='Force update even if a deployment is in progress.',
+)
+
+
 instances = click.option(
     '-i', '--instances',
     type=int,

--- a/shpkpr/commands/cmd_config.py
+++ b/shpkpr/commands/cmd_config.py
@@ -30,9 +30,10 @@ def list(logger, marathon_client, application_id):
 @cli.command('set', short_help='Set application configuration.', context_settings=CONTEXT_SETTINGS)
 @arguments.env_pairs
 @options.application_id
+@options.force
 @options.marathon_client
 @pass_logger
-def set(logger, marathon_client, application_id, env_pairs):
+def set(logger, marathon_client, force, application_id, env_pairs):
     """Set application configuration.
     """
     existing_application = marathon_client.get_application(application_id)
@@ -43,15 +44,16 @@ def set(logger, marathon_client, application_id, env_pairs):
         application['env'][k] = v
 
     # redeploy the reconfigured application
-    marathon_client.deploy_application(application).wait()
+    marathon_client.deploy_application(application, force=force).wait()
 
 
 @cli.command('unset', short_help='Unset application configuration.', context_settings=CONTEXT_SETTINGS)
 @arguments.env_keys
 @options.application_id
+@options.force
 @options.marathon_client
 @pass_logger
-def unset(logger, marathon_client, application_id, env_keys):
+def unset(logger, marathon_client, force, application_id, env_keys):
     """Unset application configuration.
     """
     existing_application = marathon_client.get_application(application_id)
@@ -64,4 +66,4 @@ def unset(logger, marathon_client, application_id, env_keys):
             pass
 
     # redeploy the reconfigured application
-    marathon_client.deploy_application(application).wait()
+    marathon_client.deploy_application(application, force=force).wait()

--- a/shpkpr/commands/cmd_deploy.py
+++ b/shpkpr/commands/cmd_deploy.py
@@ -10,15 +10,16 @@ from shpkpr.template import render_json_template
 
 
 @click.command('deploy', short_help='Deploy application from template.', context_settings=CONTEXT_SETTINGS)
+@options.force
 @options.template_file
 @options.env_prefix
 @options.marathon_client
 @pass_logger
-def cli(logger, marathon_client, env_prefix, template_file):
+def cli(logger, marathon_client, env_prefix, template_file, force):
     """Deploy application from template.
     """
     # read and render deploy template using values from the environment
     values = load_values_from_environment(prefix=env_prefix)
     rendered_template = render_json_template(template_file, **values)
 
-    marathon_client.deploy_application(rendered_template).wait()
+    marathon_client.deploy_application(rendered_template, force=force).wait()

--- a/shpkpr/commands/cmd_scale.py
+++ b/shpkpr/commands/cmd_scale.py
@@ -9,12 +9,13 @@ from shpkpr.cli.logger import pass_logger
 
 @click.command('scale', short_help='Scale application resources.', context_settings=CONTEXT_SETTINGS)
 @options.application_id
+@options.force
 @options.cpus
 @options.mem
 @options.instances
 @options.marathon_client
 @pass_logger
-def cli(logger, marathon_client, instances, mem, cpus, application_id):
+def cli(logger, marathon_client, instances, mem, cpus, force, application_id):
     """Scale application resources to specified levels.
     """
     existing_application = marathon_client.get_application(application_id)
@@ -27,4 +28,4 @@ def cli(logger, marathon_client, instances, mem, cpus, application_id):
             application[k] = v
 
     if updated:
-        marathon_client.deploy_application(application).wait()
+        marathon_client.deploy_application(application, force=force).wait()

--- a/shpkpr/marathon/client.py
+++ b/shpkpr/marathon/client.py
@@ -105,7 +105,10 @@ class MarathonClient(object):
         self.deploy_schema.validate(application)
 
         path = "/v2/apps/" + application['id']
-        params = {"force": force}
+        if force:
+            params = {"force": "true"}
+        else:
+            params = {}
         response = self._make_request('PUT', path, params=params, json=application)
 
         if response.status_code in [200, 201]:

--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -1,0 +1,27 @@
+# stdlib imports
+import functools
+import json
+import os
+
+# third-party imports
+import pytest
+from click.testing import CliRunner
+
+# local imports
+from shpkpr.cli.entrypoint import cli
+
+
+@pytest.fixture
+def runner():
+    runner = CliRunner()
+    return functools.partial(runner.invoke, cli)
+
+
+@pytest.fixture
+def json_fixture():
+    def _json_fixture(name):
+        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir, "fixtures", name + ".json")
+        with open(path, 'r') as f:
+            fixture = json.loads(f.read())
+        return fixture
+    return _json_fixture

--- a/tests/commands/test_cmd_config.py
+++ b/tests/commands/test_cmd_config.py
@@ -1,73 +1,143 @@
 # third-party imports
-from click.testing import CliRunner
-
-# local imports
-from shpkpr.cli.entrypoint import cli
+import mock
+import responses
 
 
-def test_no_args():
-    runner = CliRunner()
-    result = runner.invoke(cli, ['config'])
+def test_no_args(runner):
+    result = runner(['config'])
 
     assert result.exit_code == 0
     assert 'Usage:' in result.output
 
 
-def test_help():
-    runner = CliRunner()
-    result = runner.invoke(cli, ['config', '--help'])
+def test_help(runner):
+    result = runner(['config', '--help'])
 
     assert result.exit_code == 0
     assert 'Usage:' in result.output
     assert 'Manage application configuration.' in result.output
 
 
-def test_list_no_args():
-    runner = CliRunner()
-    result = runner.invoke(cli, ['config', 'list'])
+def test_list_no_args(runner):
+    result = runner(['config', 'list'])
 
     assert result.exit_code == 2
     assert 'Usage:' in result.output
 
 
-def test_list_help():
-    runner = CliRunner()
-    result = runner.invoke(cli, ['config', 'list', '--help'])
+def test_list_help(runner):
+    result = runner(['config', 'list', '--help'])
 
     assert result.exit_code == 0
     assert 'Usage:' in result.output
     assert 'List application configuration.' in result.output
 
 
-def test_set_no_args():
-    runner = CliRunner()
-    result = runner.invoke(cli, ['config', 'set'])
+def test_set_no_args(runner):
+    result = runner(['config', 'set'])
 
     assert result.exit_code == 2
     assert 'Usage:' in result.output
 
 
-def test_set_help():
-    runner = CliRunner()
-    result = runner.invoke(cli, ['config', 'set', '--help'])
+def test_set_help(runner):
+    result = runner(['config', 'set', '--help'])
 
     assert result.exit_code == 0
     assert 'Usage:' in result.output
     assert 'Set application configuration.' in result.output
 
 
-def test_unset_no_args():
-    runner = CliRunner()
-    result = runner.invoke(cli, ['config', 'unset'])
+@responses.activate
+@mock.patch('shpkpr.marathon.MarathonDeployment.wait')
+def test_set_no_force(mock_deployment_wait, runner, json_fixture):
+    responses.add(responses.GET,
+                  'http://marathon.somedomain.com:8080/v2/apps/test-app',
+                  status=200,
+                  json=json_fixture("valid_app"))
+    responses.add(responses.PUT,
+                  'http://marathon.somedomain.com:8080/v2/apps/test-app',
+                  status=201,
+                  json=json_fixture("deployment"),
+                  match_querystring=True)
+    mock_deployment_wait.return_value = True
+
+    env = {'SHPKPR_MARATHON_URL': "http://marathon.somedomain.com:8080"}
+    result = runner(['config', 'set', '--application', 'test-app', 'MYKEY=MYVAL'], env=env)
+
+    assert result.exit_code == 0
+
+
+@responses.activate
+@mock.patch('shpkpr.marathon.MarathonDeployment.wait')
+def test_set_force(mock_deployment_wait, runner, json_fixture):
+    responses.add(responses.GET,
+                  'http://marathon.somedomain.com:8080/v2/apps/test-app',
+                  status=200,
+                  json=json_fixture("valid_app"))
+    responses.add(responses.PUT,
+                  'http://marathon.somedomain.com:8080/v2/apps/test-app?force=true',
+                  status=201,
+                  json=json_fixture("deployment"),
+                  match_querystring=True)
+    mock_deployment_wait.return_value = True
+
+    env = {'SHPKPR_MARATHON_URL': "http://marathon.somedomain.com:8080"}
+    result = runner(['config', 'set', '--application', 'test-app', '--force', 'MYKEY=MYVAL'], env=env)
+
+    assert result.exit_code == 0
+
+
+def test_unset_no_args(runner):
+    result = runner(['config', 'unset'])
 
     assert result.exit_code == 2
     assert 'Usage:' in result.output
 
 
-def test_unset_help():
-    runner = CliRunner()
-    result = runner.invoke(cli, ['config', 'unset', '--help'])
+def test_unset_help(runner):
+    result = runner(['config', 'unset', '--help'])
 
     assert result.exit_code == 0
     assert 'Usage:' in result.output
     assert 'Unset application configuration.' in result.output
+
+
+@responses.activate
+@mock.patch('shpkpr.marathon.MarathonDeployment.wait')
+def test_unset_no_force(mock_deployment_wait, runner, json_fixture):
+    responses.add(responses.GET,
+                  'http://marathon.somedomain.com:8080/v2/apps/test-app',
+                  status=200,
+                  json=json_fixture("valid_app"))
+    responses.add(responses.PUT,
+                  'http://marathon.somedomain.com:8080/v2/apps/test-app',
+                  status=201,
+                  json=json_fixture("deployment"),
+                  match_querystring=True)
+    mock_deployment_wait.return_value = True
+
+    env = {'SHPKPR_MARATHON_URL': "http://marathon.somedomain.com:8080"}
+    result = runner(['config', 'unset', '--application', 'test-app', 'MYKEY'], env=env)
+
+    assert result.exit_code == 0
+
+
+@responses.activate
+@mock.patch('shpkpr.marathon.MarathonDeployment.wait')
+def test_unset_force(mock_deployment_wait, runner, json_fixture):
+    responses.add(responses.GET,
+                  'http://marathon.somedomain.com:8080/v2/apps/test-app',
+                  status=200,
+                  json=json_fixture("valid_app"))
+    responses.add(responses.PUT,
+                  'http://marathon.somedomain.com:8080/v2/apps/test-app?force=true',
+                  status=201,
+                  json=json_fixture("deployment"),
+                  match_querystring=True)
+    mock_deployment_wait.return_value = True
+
+    env = {'SHPKPR_MARATHON_URL': "http://marathon.somedomain.com:8080"}
+    result = runner(['config', 'unset', '--application', 'test-app', '--force', 'MYKEY'], env=env)
+
+    assert result.exit_code == 0

--- a/tests/commands/test_cmd_deploy.py
+++ b/tests/commands/test_cmd_deploy.py
@@ -1,22 +1,71 @@
+# stdlib imports
+import os
+
 # third-party imports
-from click.testing import CliRunner
-
-# local imports
-from shpkpr.cli.entrypoint import cli
+import mock
+import responses
 
 
-def test_no_args():
-    runner = CliRunner()
-    result = runner.invoke(cli, ['deploy'])
+def _test_template_path():
+    """Returns an absolute path to our test template
+    """
+    return os.path.abspath(os.path.join('tests', 'test.json.tmpl'))
+
+
+def test_no_args(runner):
+    result = runner(['deploy'])
 
     assert result.exit_code == 2
     assert 'Usage:' in result.output
 
 
-def test_help():
-    runner = CliRunner()
-    result = runner.invoke(cli, ['deploy', '--help'])
+def test_help(runner):
+    result = runner(['deploy', '--help'])
 
     assert result.exit_code == 0
     assert 'Usage:' in result.output
     assert 'Deploy application from template.' in result.output
+
+
+@responses.activate
+@mock.patch('shpkpr.marathon.MarathonDeployment.wait')
+def test_no_force(mock_deployment_wait, runner, json_fixture):
+    responses.add(responses.PUT,
+                  'http://marathon.somedomain.com:8080/v2/apps/test-app',
+                  status=201,
+                  json=json_fixture("deployment"),
+                  match_querystring=True)
+    mock_deployment_wait.return_value = True
+
+    env = {
+        'SHPKPR_MARATHON_URL': "http://marathon.somedomain.com:8080",
+        'SHPKPR_APPLICATION': 'test-app',
+        'SHPKPR_DOCKER_REPOTAG': 'goexample/outyet:latest',
+        'SHPKPR_DOCKER_EXPOSED_PORT': '8080',
+        'SHPKPR_DEPLOY_DOMAIN': 'mydomain.com',
+    }
+    result = runner(['deploy', '--template', _test_template_path()], env=env)
+
+    assert result.exit_code == 0
+
+
+@responses.activate
+@mock.patch('shpkpr.marathon.MarathonDeployment.wait')
+def test_force(mock_deployment_wait, runner, json_fixture):
+    responses.add(responses.PUT,
+                  'http://marathon.somedomain.com:8080/v2/apps/test-app?force=true',
+                  status=201,
+                  json=json_fixture("deployment"),
+                  match_querystring=True)
+    mock_deployment_wait.return_value = True
+
+    env = {
+        'SHPKPR_MARATHON_URL': "http://marathon.somedomain.com:8080",
+        'SHPKPR_APPLICATION': 'test-app',
+        'SHPKPR_DOCKER_REPOTAG': 'goexample/outyet:latest',
+        'SHPKPR_DOCKER_EXPOSED_PORT': '8080',
+        'SHPKPR_DEPLOY_DOMAIN': 'mydomain.com',
+    }
+    result = runner(['deploy', '--template', _test_template_path(), '--force'], env=env)
+
+    assert result.exit_code == 0

--- a/tests/commands/test_cmd_scale.py
+++ b/tests/commands/test_cmd_scale.py
@@ -1,22 +1,58 @@
 # third-party imports
-from click.testing import CliRunner
-
-# local imports
-from shpkpr.cli.entrypoint import cli
+import mock
+import responses
 
 
-def test_no_args():
-    runner = CliRunner()
-    result = runner.invoke(cli, ['scale'])
+def test_no_args(runner):
+    result = runner(['scale'])
 
     assert result.exit_code == 2
     assert 'Usage:' in result.output
 
 
-def test_help():
-    runner = CliRunner()
-    result = runner.invoke(cli, ['scale', '--help'])
+def test_help(runner):
+    result = runner(['scale', '--help'])
 
     assert result.exit_code == 0
     assert 'Usage:' in result.output
     assert 'Scale application resources to specified levels.' in result.output
+
+
+@responses.activate
+@mock.patch('shpkpr.marathon.MarathonDeployment.wait')
+def test_no_force(mock_deployment_wait, runner, json_fixture):
+    responses.add(responses.GET,
+                  'http://marathon.somedomain.com:8080/v2/apps/test-app',
+                  status=200,
+                  json=json_fixture("valid_app"))
+    responses.add(responses.PUT,
+                  'http://marathon.somedomain.com:8080/v2/apps/test-app',
+                  status=201,
+                  json=json_fixture("deployment"),
+                  match_querystring=True)
+    mock_deployment_wait.return_value = True
+
+    env = {'SHPKPR_MARATHON_URL': "http://marathon.somedomain.com:8080"}
+    result = runner(['scale', '--application', 'test-app', '--cpus', '0.25'], env=env)
+
+    assert result.exit_code == 0
+
+
+@responses.activate
+@mock.patch('shpkpr.marathon.MarathonDeployment.wait')
+def test_force(mock_deployment_wait, runner, json_fixture):
+    responses.add(responses.GET,
+                  'http://marathon.somedomain.com:8080/v2/apps/test-app',
+                  status=200,
+                  json=json_fixture("valid_app"))
+    responses.add(responses.PUT,
+                  'http://marathon.somedomain.com:8080/v2/apps/test-app?force=true',
+                  status=201,
+                  json=json_fixture("deployment"),
+                  match_querystring=True)
+    mock_deployment_wait.return_value = True
+
+    env = {'SHPKPR_MARATHON_URL': "http://marathon.somedomain.com:8080"}
+    result = runner(['scale', '--application', 'test-app', '--cpus', '0.25', '--force'], env=env)
+
+    assert result.exit_code == 0


### PR DESCRIPTION
This PR adds support for the `--force` flag on all commands that make changes to an application (`deploy`, `scale`, and `config` for now).

This allows a deployment to be started even if another deployment is already in progress.

Closes #4 