### PR TITLE
Jinja2 template loading

### DIFF
--- a/docs/usage/cmd_deploy.rst
+++ b/docs/usage/cmd_deploy.rst
@@ -10,12 +10,14 @@ Deploying a new application config
       Deploy application from template.
 
     Options:
-      -t, --template FILENAME  Path of the template to use for deployment.
-                               [required]
-      -e, --env_prefix TEXT    Prefix used to restrict environment vars used
-                               for templating.
-      --help                   Show this message and exit.
-
+      --force                Force update even if a deployment is in progress.
+      -t, --template TEXT    Name of the template to use for deployment.
+                             [required]
+      --template_dir TEXT    Base directory in which your templates are stored (default: `pwd`).
+      -e, --env_prefix TEXT  Prefix used to restrict environment vars used for
+                             templating.
+      --marathon_url TEXT    URL of the Marathon API to use.  [required]
+      --help                 Show this message and exit.
 
 Required Configuration
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -27,9 +29,9 @@ Required Configuration
     * Environment variable: ``SHPKPR_MARATHON_URL``
     * Command-line flag: ``--marathon_url``
 
-**JSON Template Path:**
+**JSON Template Name:**
 
-    Path of the JSON template to use for deployment, e.g. ``/some/path/to/a/template.json.tmpl`` or ``./my-template.json.tmpl``
+    Name of the JSON template to use for deployment, e.g. ``a/template.json.tmpl`` or ``my-template.json.tmpl``. This path should always be relative to the template base directory defined by ``--template-dir`` (``pwd`` by default).
 
     * Environment variable: ``SHPKPR_TEMPLATE``
     * Command-line flag: ``--template``
@@ -53,6 +55,11 @@ Optional Configuration
     * Command-line flag: ``--env_prefix``
     * Default: ``SHPKPR_``
 
+**Base Template Directory:**
+
+    Absolute path to the base directory in which templates are stored. By default this is ``pwd`` but can be overridden to allow reading templates from any location on the filesystem. This setting is useful when using templates not found in ``pwd`` or controlling exactly how template inheritance should work. The specified directory is passed to a ``jinja2.FilesystemLoader`` within ``shpkpr``.
+
+    * Command-line flag: ``--template_dir``
 
 Examples
 ^^^^^^^^

--- a/shpkpr/cli/options.py
+++ b/shpkpr/cli/options.py
@@ -5,6 +5,9 @@ define their options directly, instead all options should be defined here and
 imported as required. This helps maintain consistency where a single option is
 used for multiple commands.
 """
+# stdlib imports
+import os
+
 # third-party imports
 import click
 
@@ -110,11 +113,21 @@ stream = click.option(
 )
 
 
-template_file = click.option(
+template_path = click.option(
+    '--template_dir',
+    'template_path',
+    envvar="{0}_TEMPLATE_DIR".format(CONTEXT_SETTINGS['auto_envvar_prefix']),
+    type=str,
+    default=os.getcwd(),
+    help="Base directory in which your templates are stored.",
+)
+
+
+template_name = click.option(
     '-t', '--template',
-    'template_file',
+    'template_name',
     envvar="{0}_TEMPLATE".format(CONTEXT_SETTINGS['auto_envvar_prefix']),
-    type=click.File("r"),
+    type=str,
     required=True,
     help="Path of the template to use for deployment.",
 )

--- a/shpkpr/commands/cmd_deploy.py
+++ b/shpkpr/commands/cmd_deploy.py
@@ -11,15 +11,16 @@ from shpkpr.template import render_json_template
 
 @click.command('deploy', short_help='Deploy application from template.', context_settings=CONTEXT_SETTINGS)
 @options.force
-@options.template_file
+@options.template_name
+@options.template_path
 @options.env_prefix
 @options.marathon_client
 @pass_logger
-def cli(logger, marathon_client, env_prefix, template_file, force):
+def cli(logger, marathon_client, env_prefix, template_path, template_name, force):
     """Deploy application from template.
     """
     # read and render deploy template using values from the environment
     values = load_values_from_environment(prefix=env_prefix)
-    rendered_template = render_json_template(template_file, **values)
+    rendered_template = render_json_template(template_path, template_name, **values)
 
     marathon_client.deploy_application(rendered_template, force=force).wait()

--- a/shpkpr/exceptions.py
+++ b/shpkpr/exceptions.py
@@ -37,6 +37,8 @@ def rewrap(exceptions_to_catch, exception_to_rewrap_with=ShpkprException):
                 if six.PY2:
                     six.reraise(exception_to_rewrap_with, ei.message, tb)
                 else:
-                    six.reraise(exception_to_rewrap_with, exception_to_rewrap_with(*ei.args), tb)
+                    ei_args = ei.args if ei.args else (ei.message,) if hasattr(ei, "message") else None
+                    ei_args = ei_args if ei_args is not None else (str(ei),)
+                    six.reraise(exception_to_rewrap_with, exception_to_rewrap_with(*ei_args), tb)
         return wrapper
     return real_decorator

--- a/shpkpr/template.py
+++ b/shpkpr/template.py
@@ -32,6 +32,15 @@ class UndefinedError(exceptions.ShpkprException):
         return 'Unable to render template: %s' % self.message
 
 
+class MissingTemplateError(exceptions.ShpkprException):
+    """Raised when a template cannot be loaded for any reason.
+    """
+    exit_code = 2
+
+    def format_message(self):
+        return 'Unable to load template from disk: %s' % self.message
+
+
 def load_values_from_environment(prefix=""):
     """Reads values from the environment.
 
@@ -51,6 +60,7 @@ def load_values_from_environment(prefix=""):
 
 @exceptions.rewrap(ValueError, InvalidJSONError)
 @exceptions.rewrap(jinja2.UndefinedError, UndefinedError)
+@exceptions.rewrap(jinja2.TemplateNotFound, MissingTemplateError)
 def render_json_template(template_path, template_name, **values):
     """Initialise a jinja2 template and render it with the passed-in values.
 

--- a/tests/commands/test_cmd_deploy.py
+++ b/tests/commands/test_cmd_deploy.py
@@ -1,15 +1,6 @@
-# stdlib imports
-import os
-
 # third-party imports
 import mock
 import responses
-
-
-def _test_template_path():
-    """Returns an absolute path to our test template
-    """
-    return os.path.abspath(os.path.join('tests', 'test.json.tmpl'))
 
 
 def test_no_args(runner):
@@ -44,7 +35,7 @@ def test_no_force(mock_deployment_wait, runner, json_fixture):
         'SHPKPR_DOCKER_EXPOSED_PORT': '8080',
         'SHPKPR_DEPLOY_DOMAIN': 'mydomain.com',
     }
-    result = runner(['deploy', '--template', _test_template_path()], env=env)
+    result = runner(['deploy', '--template', 'tests/test.json.tmpl'], env=env)
 
     assert result.exit_code == 0
 
@@ -66,6 +57,6 @@ def test_force(mock_deployment_wait, runner, json_fixture):
         'SHPKPR_DOCKER_EXPOSED_PORT': '8080',
         'SHPKPR_DEPLOY_DOMAIN': 'mydomain.com',
     }
-    result = runner(['deploy', '--template', _test_template_path(), '--force'], env=env)
+    result = runner(['deploy', '--template', 'tests/test.json.tmpl', '--force'], env=env)
 
     assert result.exit_code == 0

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,9 +1,3 @@
-# stdlib imports
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
-
 # third-party imports
 import pytest
 
@@ -18,6 +12,16 @@ from shpkpr.template_filters import IntegerTooSmall
 from shpkpr.template_filters import FloatRequired
 from shpkpr.template_filters import FloatTooLarge
 from shpkpr.template_filters import FloatTooSmall
+
+
+def _write_template_to_disk(tmpdir, template_name, template_data):
+    """shpkpr loads template files from disk normally. This convenience
+    function writes a template file to disk and returns a (directory, name)
+    tuple.
+    """
+    with tmpdir.join(template_name).open("w") as f:
+        f.write(template_data)
+    return (tmpdir.strpath, template_name)
 
 
 def test_load_environment_vars_without_prefix(monkeypatch):
@@ -69,37 +73,51 @@ def test_load_environment_vars_with_prefix_with_trailing_underscore(monkeypatch)
     assert values['SHPKPR_APPLE_AND_BLACKCURRANT'] == 'crumble'
 
 
-def test_render_json_template_valid():
-    template_file = StringIO('{"type_of_muffin": "{{ MUFFIN_TYPE }}"}')
+def test_render_json_template_valid(tmpdir):
+    template_path, template_name = _write_template_to_disk(
+        tmpdir, 'template.json',
+        '{"type_of_muffin": "{{ MUFFIN_TYPE }}"}',
+    )
 
-    rendered_template = render_json_template(template_file, **{"MUFFIN_TYPE": "banana"})
+    rendered_template = render_json_template(template_path, template_name, **{"MUFFIN_TYPE": "banana"})
     assert "type_of_muffin" in rendered_template
     assert rendered_template["type_of_muffin"] == "banana"
 
 
-def test_render_json_template_invalid_json_unquoted_string():
-    template_file = StringIO('{"type_of_muffin": {{ MUFFIN_TYPE }}}')
+def test_render_json_template_invalid_json_unquoted_string(tmpdir):
+    template_path, template_name = _write_template_to_disk(
+        tmpdir, 'template.json',
+        '{"type_of_muffin": {{ MUFFIN_TYPE }}}',
+    )
 
     with pytest.raises(InvalidJSONError):
-        render_json_template(template_file, **{"MUFFIN_TYPE": "banana"})
+        render_json_template(template_path, template_name, **{"MUFFIN_TYPE": "banana"})
 
 
-def test_render_json_template_invalid_json_missing_value():
-    template_file = StringIO('{"type_of_muffin": {{ MUFFIN_TYPE }}}')
+def test_render_json_template_invalid_json_missing_value(tmpdir):
+    template_path, template_name = _write_template_to_disk(
+        tmpdir, 'template.json',
+        '{"type_of_muffin": {{ MUFFIN_TYPE }}}',
+    )
 
     with pytest.raises(InvalidJSONError):
-        render_json_template(template_file, **{"MUFFIN_TYPE": ""})
+        render_json_template(template_path, template_name, **{"MUFFIN_TYPE": ""})
 
 
-def test_render_json_template_missing_value_raises():
-    template_file = StringIO('{"type_of_muffin": "{{ MUFFIN_TYPE }}"}')
+def test_render_json_template_missing_value_raises(tmpdir):
+    template_path, template_name = _write_template_to_disk(
+        tmpdir, 'template.json',
+        '{"type_of_muffin": "{{ MUFFIN_TYPE }}"}',
+    )
 
     with pytest.raises(UndefinedError):
-        render_json_template(template_file, **{})
+        render_json_template(template_path, template_name, **{})
 
 
-def test_render_json_template_all_env():
-    template_file = StringIO('''
+def test_render_json_template_all_env(tmpdir):
+    template_path, template_name = _write_template_to_disk(
+        tmpdir, 'template.json',
+        '''
         {
             "types_of_muffin": {
                 {% for k, v in _all_env|filter_items("MUFFIN_", True) %}
@@ -107,9 +125,10 @@ def test_render_json_template_all_env():
                 {% endfor %}
             }
         }
-    ''')
+        ''',
+    )
 
-    rendered_template = render_json_template(template_file, **{
+    rendered_template = render_json_template(template_path, template_name, **{
         "MUFFIN_BLUEBERRY": 4,
         "MUFFIN_BANANA": 7,
         "MUFFIN_CHOCOLATE": 12,
@@ -121,85 +140,121 @@ def test_render_json_template_all_env():
     assert rendered_template["types_of_muffin"]["chocolate"] == 12
 
 
-def test_render_json_template_require_int():
-    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_int }}}')
+def test_render_json_template_require_int(tmpdir):
+    template_path, template_name = _write_template_to_disk(
+        tmpdir, 'template.json',
+        '{"muffin_count": {{ MUFFIN_COUNT|require_int }}}',
+    )
 
-    rendered_template = render_json_template(template_file, **{"MUFFIN_COUNT": "1"})
+    rendered_template = render_json_template(template_path, template_name, **{"MUFFIN_COUNT": "1"})
     assert rendered_template['muffin_count'] == 1
 
 
-def test_render_json_template_require_int_requires_int():
-    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_int }}}')
+def test_render_json_template_require_int_requires_int(tmpdir):
+    template_path, template_name = _write_template_to_disk(
+        tmpdir, 'template.json',
+        '{"muffin_count": {{ MUFFIN_COUNT|require_int }}}',
+    )
 
     with pytest.raises(IntegerRequired):
-        render_json_template(template_file, **{"MUFFIN_COUNT": "one muffin"})
+        render_json_template(template_path, template_name, **{"MUFFIN_COUNT": "one muffin"})
 
 
-def test_render_json_template_require_int_min_constraint():
-    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_int(min=50) }}}')
+def test_render_json_template_require_int_min_constraint(tmpdir):
+    template_path, template_name = _write_template_to_disk(
+        tmpdir, 'template.json',
+        '{"muffin_count": {{ MUFFIN_COUNT|require_int(min=50) }}}',
+    )
 
-    rendered_template = render_json_template(template_file, **{"MUFFIN_COUNT": "60"})
+    rendered_template = render_json_template(template_path, template_name, **{"MUFFIN_COUNT": "60"})
     assert rendered_template['muffin_count'] == 60
 
 
-def test_render_json_template_require_int_min_constraint_raises():
-    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_int(min=50) }}}')
+def test_render_json_template_require_int_min_constraint_raises(tmpdir):
+    template_path, template_name = _write_template_to_disk(
+        tmpdir, 'template.json',
+        '{"muffin_count": {{ MUFFIN_COUNT|require_int(min=50) }}}',
+    )
 
     with pytest.raises(IntegerTooSmall):
-        render_json_template(template_file, **{"MUFFIN_COUNT": "40"})
+        render_json_template(template_path, template_name, **{"MUFFIN_COUNT": "40"})
 
 
-def test_render_json_template_require_int_max_constraint():
-    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_int(max=50) }}}')
+def test_render_json_template_require_int_max_constraint(tmpdir):
+    template_path, template_name = _write_template_to_disk(
+        tmpdir, 'template.json',
+        '{"muffin_count": {{ MUFFIN_COUNT|require_int(max=50) }}}',
+    )
 
-    rendered_template = render_json_template(template_file, **{"MUFFIN_COUNT": "-60"})
+    rendered_template = render_json_template(template_path, template_name, **{"MUFFIN_COUNT": "-60"})
     assert rendered_template['muffin_count'] == -60
 
 
-def test_render_json_template_require_int_max_constraint_raises():
-    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_int(max=50) }}}')
+def test_render_json_template_require_int_max_constraint_raises(tmpdir):
+    template_path, template_name = _write_template_to_disk(
+        tmpdir, 'template.json',
+        '{"muffin_count": {{ MUFFIN_COUNT|require_int(max=50) }}}',
+    )
 
     with pytest.raises(IntegerTooLarge):
-        render_json_template(template_file, **{"MUFFIN_COUNT": "60"})
+        render_json_template(template_path, template_name, **{"MUFFIN_COUNT": "60"})
 
 
-def test_render_json_template_require_float():
-    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_float }}}')
+def test_render_json_template_require_float(tmpdir):
+    template_path, template_name = _write_template_to_disk(
+        tmpdir, 'template.json',
+        '{"muffin_count": {{ MUFFIN_COUNT|require_float }}}',
+    )
 
-    rendered_template = render_json_template(template_file, **{"MUFFIN_COUNT": "1.01"})
+    rendered_template = render_json_template(template_path, template_name, **{"MUFFIN_COUNT": "1.01"})
     assert rendered_template['muffin_count'] == 1.01
 
 
-def test_render_json_template_require_float_requires_float():
-    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_float }}}')
+def test_render_json_template_require_float_requires_float(tmpdir):
+    template_path, template_name = _write_template_to_disk(
+        tmpdir, 'template.json',
+        '{"muffin_count": {{ MUFFIN_COUNT|require_float }}}',
+    )
 
     with pytest.raises(FloatRequired):
-        render_json_template(template_file, **{"MUFFIN_COUNT": "one muffin"})
+        render_json_template(template_path, template_name, **{"MUFFIN_COUNT": "one muffin"})
 
 
-def test_render_json_template_require_float_min_constraint():
-    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_float(min=50) }}}')
+def test_render_json_template_require_float_min_constraint(tmpdir):
+    template_path, template_name = _write_template_to_disk(
+        tmpdir, 'template.json',
+        '{"muffin_count": {{ MUFFIN_COUNT|require_float(min=50) }}}',
+    )
 
-    rendered_template = render_json_template(template_file, **{"MUFFIN_COUNT": "60"})
+    rendered_template = render_json_template(template_path, template_name, **{"MUFFIN_COUNT": "60"})
     assert rendered_template['muffin_count'] == 60
 
 
-def test_render_json_template_require_float_min_constraint_raises():
-    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_float(min=50) }}}')
+def test_render_json_template_require_float_min_constraint_raises(tmpdir):
+    template_path, template_name = _write_template_to_disk(
+        tmpdir, 'template.json',
+        '{"muffin_count": {{ MUFFIN_COUNT|require_float(min=50) }}}',
+    )
 
     with pytest.raises(FloatTooSmall):
-        render_json_template(template_file, **{"MUFFIN_COUNT": "40"})
+        render_json_template(template_path, template_name, **{"MUFFIN_COUNT": "40"})
 
 
-def test_render_json_template_require_float_max_constraint():
-    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_float(max=50) }}}')
+def test_render_json_template_require_float_max_constraint(tmpdir):
+    template_path, template_name = _write_template_to_disk(
+        tmpdir, 'template.json',
+        '{"muffin_count": {{ MUFFIN_COUNT|require_float(max=50) }}}',
+    )
 
-    rendered_template = render_json_template(template_file, **{"MUFFIN_COUNT": "-60"})
+    rendered_template = render_json_template(template_path, template_name, **{"MUFFIN_COUNT": "-60"})
     assert rendered_template['muffin_count'] == -60
 
 
-def test_render_json_template_require_float_max_constraint_raises():
-    template_file = StringIO('{"muffin_count": {{ MUFFIN_COUNT|require_float(max=50) }}}')
+def test_render_json_template_require_float_max_constraint_raises(tmpdir):
+    template_path, template_name = _write_template_to_disk(
+        tmpdir, 'template.json',
+        '{"muffin_count": {{ MUFFIN_COUNT|require_float(max=50) }}}',
+    )
 
     with pytest.raises(FloatTooLarge):
-        render_json_template(template_file, **{"MUFFIN_COUNT": "60"})
+        render_json_template(template_path, template_name, **{"MUFFIN_COUNT": "60"})


### PR DESCRIPTION
This PR changes template loading behaviour to use a proper `jinja2.FilesystemLoader`. This allows the use of more advanced template features such as inheritance (useful in a project with multiple deploys but only very slightly differing configurations).

**NOTE:** This PR changes/breaks the public-facing API of `shpkpr` slightly. I explored alternative approaches that wouldn't have broken the API, but this explicit approach (specifying both the template dir and name) makes the most sense, has the least surprises and weird edge cases and will be familiar to anyone who has used Jinja2 or Django templates in the past.

Closes #51