### PR TITLE
Template variables from CLI

### DIFF
--- a/docs/usage/cmd_deploy.rst
+++ b/docs/usage/cmd_deploy.rst
@@ -5,7 +5,7 @@ Deploying a new application config
 ``shpkpr deploy`` allows you to deploy a new (or changes to an existing) application configuration by rendering and POSTing a JSON template to Marathon::
 
     $ shpkpr deploy --help
-    Usage: shpkpr deploy [OPTIONS]
+    Usage: shpkpr deploy [OPTIONS] [ENV_PAIRS]...
 
       Deploy application from template.
 
@@ -18,6 +18,8 @@ Deploying a new application config
                              templating.
       --marathon_url TEXT    URL of the Marathon API to use.  [required]
       --help                 Show this message and exit.
+
+Additional template values can be passed on the command line in a KEY=VALUE format. Any number of key/value pairs can be passed. See below for a few examples.
 
 Required Configuration
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -74,7 +76,8 @@ Examples
       "mem": 512,
       "instances": {{INSTANCES|require_int(min=1, max=16)}},
       "labels": {
-        "DOMAIN": "{{LABEL_DOMAIN}}"
+        "DOMAIN": "{{LABEL_DOMAIN}}",
+        "RANDOM_LABEL": "{{RANDOM_LABEL}}"
       }
     }
 
@@ -84,7 +87,7 @@ Examples
     $ export SHPKPR_CMD="sleep 60"
     $ export SHPKPR_LABEL_DOMAIN=mydomain.com
 
-    $ shpkpr deploy -t deploy.json.tmpl
+    $ shpkpr deploy -t deploy.json.tmpl RANDOM_LABEL=my_value
 
     # Would result in the following output sent to Marathon
     # {
@@ -94,7 +97,8 @@ Examples
     #   "mem": 512,
     #   "instances": 2,
     #   "labels": {
-    #     "DOMAIN": "mydomain.com"
+    #     "DOMAIN": "mydomain.com",
+    #     "RANDOM_LABEL": "my_value"
     #   }
     # }
 ::

--- a/shpkpr/cli/arguments.py
+++ b/shpkpr/cli/arguments.py
@@ -9,9 +9,23 @@ argument is used for multiple commands.
 import click
 
 
+def _env_pairs_to_dict(ctx, param, value):
+    """Converts a space-seperated list of key=value pairs into a Python
+    dictionary.
+    """
+    d = {}
+    for pair in [x.split('=', 1) for x in value]:
+        if len(pair) == 1:
+            d[pair[0]] = ''
+        else:
+            d[pair[0]] = pair[1]
+    return d
+
+
 env_pairs = click.argument(
     'env_pairs',
     nargs=-1,
+    callback=_env_pairs_to_dict,
 )
 
 

--- a/shpkpr/commands/cmd_config.py
+++ b/shpkpr/commands/cmd_config.py
@@ -39,7 +39,6 @@ def set(logger, marathon_client, force, application_id, env_pairs):
     existing_application = marathon_client.get_application(application_id)
     application = {'id': application_id, 'env': existing_application['env']}
 
-    env_pairs = dict([(x[0], x[1]) for x in [y.split('=') for y in env_pairs]])
     for k, v in env_pairs.items():
         application['env'][k] = v
 

--- a/shpkpr/commands/cmd_deploy.py
+++ b/shpkpr/commands/cmd_deploy.py
@@ -2,6 +2,7 @@
 import click
 
 # local imports
+from shpkpr.cli import arguments
 from shpkpr.cli import options
 from shpkpr.cli.entrypoint import CONTEXT_SETTINGS
 from shpkpr.cli.logger import pass_logger
@@ -10,17 +11,18 @@ from shpkpr.template import render_json_template
 
 
 @click.command('deploy', short_help='Deploy application from template.', context_settings=CONTEXT_SETTINGS)
+@arguments.env_pairs
 @options.force
 @options.template_name
 @options.template_path
 @options.env_prefix
 @options.marathon_client
 @pass_logger
-def cli(logger, marathon_client, env_prefix, template_path, template_name, force):
+def cli(logger, marathon_client, env_prefix, template_path, template_name, force, env_pairs):
     """Deploy application from template.
     """
     # read and render deploy template using values from the environment
-    values = load_values_from_environment(prefix=env_prefix)
+    values = load_values_from_environment(prefix=env_prefix, overrides=env_pairs)
     rendered_template = render_json_template(template_path, template_name, **values)
 
     marathon_client.deploy_application(rendered_template, force=force).wait()

--- a/shpkpr/template.py
+++ b/shpkpr/template.py
@@ -41,20 +41,35 @@ class MissingTemplateError(exceptions.ShpkprException):
         return 'Unable to load template from disk: %s' % self.message
 
 
-def load_values_from_environment(prefix=""):
+def load_values_from_environment(prefix="", overrides=None):
     """Reads values from the environment.
 
     If ``prefix`` is a non-empty string, only environment variables with the
     given prefix will be returned. The prefix, if given, will be stripped from
     any returned keys.
+
+    If ``overrides`` is a dict-like object, the key/value pairs it contains
+    will be added to the returned dictionary. Any values specified by
+    overrides will take precedence over values pulled from the environment
+    where the key names clash.
     """
+    values = {}
+
     # add a trailing underscore to the prefix if there isn't one
     prefix = prefix + "_" if prefix and not prefix.endswith("_") else prefix
 
-    values = {}
+    # load values from the environment
     for k, v in os.environ.items():
         if k.startswith(prefix):
             values[k.replace(prefix, "", 1)] = v
+
+    # add override values if any passed in
+    try:
+        for k, v in overrides.items():
+            values[k] = v
+    except AttributeError:
+        pass
+
     return values
 
 

--- a/tests/cli/test_arguments.py
+++ b/tests/cli/test_arguments.py
@@ -1,0 +1,27 @@
+# third-party imports
+import click
+from click.testing import CliRunner
+
+# local imports
+from shpkpr.cli import arguments
+
+
+def test_env_pairs():
+
+    @click.command()
+    @arguments.env_pairs
+    def greet(env_pairs):
+        for k, v in env_pairs.items():
+            click.echo('(%s: %s)' % (k, v))
+
+    result = CliRunner().invoke(greet, [
+        'shp=kpr',
+        'MYKEY=MYVALUE',
+        'MY_OTHER_KEY=MY_OTHER=VALUE',
+        'EMPTY_KEY',
+    ])
+
+    assert '(shp: kpr)' in result.output
+    assert '(MYKEY: MYVALUE)' in result.output
+    assert '(MY_OTHER_KEY: MY_OTHER=VALUE)' in result.output
+    assert '(EMPTY_KEY: )' in result.output

--- a/tests/commands/test_cmd_deploy.py
+++ b/tests/commands/test_cmd_deploy.py
@@ -35,7 +35,7 @@ def test_no_force(mock_deployment_wait, runner, json_fixture):
         'SHPKPR_DOCKER_EXPOSED_PORT': '8080',
         'SHPKPR_DEPLOY_DOMAIN': 'mydomain.com',
     }
-    result = runner(['deploy', '--template', 'tests/test.json.tmpl'], env=env)
+    result = runner(['deploy', '--template', 'tests/test.json.tmpl', 'RANDOM_LABEL=some_value'], env=env)
 
     assert result.exit_code == 0
 
@@ -57,6 +57,6 @@ def test_force(mock_deployment_wait, runner, json_fixture):
         'SHPKPR_DOCKER_EXPOSED_PORT': '8080',
         'SHPKPR_DEPLOY_DOMAIN': 'mydomain.com',
     }
-    result = runner(['deploy', '--template', 'tests/test.json.tmpl', '--force'], env=env)
+    result = runner(['deploy', '--template', 'tests/test.json.tmpl', '--force', 'RANDOM_LABEL=some_value'], env=env)
 
     assert result.exit_code == 0

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -30,7 +30,7 @@ def test_list(runner, env):
 
 @pytest.mark.integration
 def test_deploy(runner, env):
-    result = runner(["deploy", "-t", "tests/test.json.tmpl"], env=env)
+    result = runner(["deploy", "-t", "tests/test.json.tmpl", "RANDOM_LABEL=some_value"], env=env)
     _check_exits_zero(result)
 
 

--- a/tests/test.json.tmpl
+++ b/tests/test.json.tmpl
@@ -44,6 +44,7 @@
   },
   "labels": {
     "HAPROXY_MODE": "http",
-    "DOMAIN": "{{DEPLOY_DOMAIN}}"
+    "DOMAIN": "{{DEPLOY_DOMAIN}}",
+    "RANDOM_LABEL": "{{RANDOM_LABEL}}"
   }
 }


### PR DESCRIPTION
This PR allows the user to specify template variables on the CLI when deploying (in addition to the already supported env vars, e.g:

```bash
$ shpkpr deploy -t deploy.json.tmpl
$ shpkpr deploy -t deploy.json.tmpl RANDOM_NUMBER=42
$ shpkpr deploy -t deploy.json.tmpl RANDOM_LABEL=my_value OTHER_LABEL=other_value
```

Closes #27 