### PR TITLE
Simplified deployment checks

### DIFF
--- a/shpkpr/marathon/__init__.py
+++ b/shpkpr/marathon/__init__.py
@@ -2,12 +2,14 @@
 from .client import ClientError
 from .client import MarathonClient
 from .deployment import DeploymentFailed
+from .deployment import DeploymentNotFound
 from .deployment import MarathonDeployment
 
 
 __all__ = [
     'ClientError',
     'DeploymentFailed',
+    'DeploymentNotFound',
     'MarathonClient',
     'MarathonDeployment',
 ]


### PR DESCRIPTION
This PR simplifies deployment checks for `shpkpr` to better follow Marathon semantics. Marathon has no concept of a successful or failed deploy, only that a particular deploy is currently in progress or not.

This change causes shpkpr to assume that any accepted deploy (with a 200/201 response) is successful and the spinning on `.wait()` now simply blocks until the deploy is removed from the active list.

This also fixes the `Error: version mismatch: xx != yy` problems that some users seen when redeploying identical versions of an app.

This PR is neccessary to implement #50 (the work for that will be carried out in another PR)