### PR TITLE
Multi-app deploys with Marathon >=0.13

### DIFF
--- a/docs/usage/cmd_deploy.rst
+++ b/docs/usage/cmd_deploy.rst
@@ -38,6 +38,8 @@ Required Configuration
     * Environment variable: ``SHPKPR_TEMPLATE``
     * Command-line flag: ``--template``
 
+    **NOTE:** When running Marathon >0.13.0 it is possible to deploy multiple applications at the same time either by specifying the ``--template`` option multiple times, or by using a single template which contains a list of individual applications.
+
 Optional Configuration
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/shpkpr/cli/options.py
+++ b/shpkpr/cli/options.py
@@ -123,11 +123,12 @@ template_path = click.option(
 )
 
 
-template_name = click.option(
+template_names = click.option(
     '-t', '--template',
-    'template_name',
-    envvar="{0}_TEMPLATE".format(CONTEXT_SETTINGS['auto_envvar_prefix']),
+    'template_names',
+    envvar="{0}_TEMPLATES".format(CONTEXT_SETTINGS['auto_envvar_prefix']),
     type=str,
     required=True,
     help="Path of the template to use for deployment.",
+    multiple=True,
 )

--- a/shpkpr/commands/cmd_config.py
+++ b/shpkpr/commands/cmd_config.py
@@ -43,7 +43,7 @@ def set(logger, marathon_client, force, application_id, env_pairs):
         application['env'][k] = v
 
     # redeploy the reconfigured application
-    marathon_client.deploy_application(application, force=force).wait()
+    marathon_client.deploy(application, force=force).wait()
 
 
 @cli.command('unset', short_help='Unset application configuration.', context_settings=CONTEXT_SETTINGS)
@@ -65,4 +65,4 @@ def unset(logger, marathon_client, force, application_id, env_keys):
             pass
 
     # redeploy the reconfigured application
-    marathon_client.deploy_application(application, force=force).wait()
+    marathon_client.deploy(application, force=force).wait()

--- a/shpkpr/commands/cmd_deploy.py
+++ b/shpkpr/commands/cmd_deploy.py
@@ -13,16 +13,18 @@ from shpkpr.template import render_json_template
 @click.command('deploy', short_help='Deploy application from template.', context_settings=CONTEXT_SETTINGS)
 @arguments.env_pairs
 @options.force
-@options.template_name
+@options.template_names
 @options.template_path
 @options.env_prefix
 @options.marathon_client
 @pass_logger
-def cli(logger, marathon_client, env_prefix, template_path, template_name, force, env_pairs):
+def cli(logger, marathon_client, env_prefix, template_path, template_names, force, env_pairs):
     """Deploy application from template.
     """
     # read and render deploy template using values from the environment
     values = load_values_from_environment(prefix=env_prefix, overrides=env_pairs)
-    rendered_template = render_json_template(template_path, template_name, **values)
+    rendered_templates = []
+    for template_name in template_names:
+        rendered_templates.append(render_json_template(template_path, template_name, **values))
 
-    marathon_client.deploy_application(rendered_template, force=force).wait()
+    marathon_client.deploy(rendered_templates, force=force).wait()

--- a/shpkpr/commands/cmd_scale.py
+++ b/shpkpr/commands/cmd_scale.py
@@ -28,4 +28,4 @@ def cli(logger, marathon_client, instances, mem, cpus, force, application_id):
             application[k] = v
 
     if updated:
-        marathon_client.deploy_application(application, force=force).wait()
+        marathon_client.deploy(application, force=force).wait()

--- a/shpkpr/marathon/client.py
+++ b/shpkpr/marathon/client.py
@@ -129,7 +129,8 @@ class MarathonClient(object):
 
         # raise an appropriate error if something went wrong
         if response.status_code == 409:
-            raise ClientError("App(s) locked by one or more deployments: %s" % response.json()['deployments'][0]['id'])
+            deployment_ids = ', '.join([x['id'] for x in response.json()['deployments']])
+            raise ClientError("App(s) locked by one or more deployments: %s" % deployment_ids)
 
         raise ClientError("Unknown Marathon error: %s\n\n%s" % (response.status_code, response.text))
 

--- a/shpkpr/marathon/client.py
+++ b/shpkpr/marathon/client.py
@@ -100,17 +100,28 @@ class MarathonClient(object):
 
         return sorted([app['id'].lstrip('/') for app in self.list_applications()])
 
-    def deploy_application(self, application, force=False):
-        """Deploys the given application to Marathon.
+    def deploy(self, application_payload, force=False):
+        """Deploys the given application(s) to Marathon.
         """
-        self.deploy_schema.validate(application)
+        # if the payload is a list and is one element long then we extract it
+        # as we want to treat single app deploys differently. Doing this here
+        # helps keep the cmd implementation clean.
+        if isinstance(application_payload, (list, tuple)) and len(application_payload) == 1:
+            application_payload = application_payload[0]
 
-        path = "/v2/apps/" + application['id']
-        if force:
-            params = {"force": "true"}
+        # if at this point our payload is a dict then we treat it as a single
+        # app, otherwise we treat it as a list of multiple applications to be
+        # deployed together.
+        if isinstance(application_payload, (list, tuple)):
+            for application in application_payload:
+                self.deploy_schema.validate(application)
+            path = "/v2/apps/"
         else:
-            params = {}
-        response = self._make_request('PUT', path, params=params, json=application)
+            self.deploy_schema.validate(application_payload)
+            path = "/v2/apps/" + application_payload['id']
+
+        params = {"force": "true"} if force else {}
+        response = self._make_request('PUT', path, params=params, json=application_payload)
 
         if response.status_code in [200, 201]:
             deployment = response.json()
@@ -118,7 +129,7 @@ class MarathonClient(object):
 
         # raise an appropriate error if something went wrong
         if response.status_code == 409:
-            raise ClientError("App is locked by one or more deployments: %s" % response.json()['deployments'][0]['id'])
+            raise ClientError("App(s) locked by one or more deployments: %s" % response.json()['deployments'][0]['id'])
 
         raise ClientError("Unknown Marathon error: %s\n\n%s" % (response.status_code, response.text))
 

--- a/tests/commands/test_cmd_deploy.py
+++ b/tests/commands/test_cmd_deploy.py
@@ -60,3 +60,27 @@ def test_force(mock_deployment_wait, runner, json_fixture):
     result = runner(['deploy', '--template', 'tests/test.json.tmpl', '--force', 'RANDOM_LABEL=some_value'], env=env)
 
     assert result.exit_code == 0
+
+
+@responses.activate
+@mock.patch('shpkpr.marathon.MarathonDeployment.wait')
+def test_multiple_templates(mock_deployment_wait, runner, json_fixture):
+    responses.add(responses.PUT,
+                  'http://marathon.somedomain.com:8080/v2/apps/',
+                  status=201,
+                  json=json_fixture("deployment"),
+                  match_querystring=True)
+    mock_deployment_wait.return_value = True
+
+    env = {
+        'SHPKPR_MARATHON_URL': "http://marathon.somedomain.com:8080",
+        'SHPKPR_APPLICATION': 'test-app',
+        'SHPKPR_APPLICATION_2': 'test-app-2',
+        'SHPKPR_DOCKER_REPOTAG': 'goexample/outyet:latest',
+        'SHPKPR_DOCKER_EXPOSED_PORT': '8080',
+        'SHPKPR_DEPLOY_DOMAIN': 'mydomain.com',
+        'SHPKPR_RANDOM_LABEL': 'some_value',
+    }
+    result = runner(['deploy', '--template', 'tests/test.json.tmpl', '--template', 'tests/test-2.json.tmpl'], env=env)
+
+    assert result.exit_code == 0

--- a/tests/fixtures/deployments.json
+++ b/tests/fixtures/deployments.json
@@ -1,0 +1,31 @@
+[
+  {
+    "id": "97c136bf-5a28-4821-9d94-480d9fbb01c8",
+    "version": "2015-09-30T09:09:17.614Z",
+    "affectedApps": [
+      "/foo"
+    ],
+    "steps": [
+      [
+        {
+          "action": "StartApplication",
+          "app": "/foo"
+        }
+      ],
+      [
+        {
+          "action": "ScaleApplication",
+          "app": "/foo"
+        }
+      ]
+    ],
+    "currentActions": [
+      {
+        "action": "ScaleApplication",
+        "app": "/foo"
+      }
+    ],
+    "currentStep": 2,
+    "totalSteps": 2
+  }
+]

--- a/tests/test-2.json.tmpl
+++ b/tests/test-2.json.tmpl
@@ -1,0 +1,50 @@
+{
+  "id": "{{APPLICATION_2}}",
+  "cpus": 0.1,
+  "mem": 512,
+  "instances": 1,
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{DOCKER_REPOTAG}}",
+      "forcePullImage": false,
+      "network": "BRIDGE",
+      "portMappings": [
+        {
+          "containerPort": {{DOCKER_EXPOSED_PORT}},
+          "hostPort": 0,
+          "protocol": "tcp"
+        }
+      ]
+    }
+  },
+  "healthChecks": [
+    {
+      "path": "/",
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 10,
+      "timeoutSeconds": 5,
+      "maxConsecutiveFailures": 3
+    }
+  ],
+  "constraints": [
+    [
+      "hostname",
+      "UNIQUE"
+    ],
+    [
+      "subnet", "LIKE", "internal"
+    ]
+  ],
+  "upgradeStrategy": {
+      "minimumHealthCapacity": 1,
+      "maximumOverCapacity": 1
+  },
+  "labels": {
+    "HAPROXY_MODE": "http",
+    "DOMAIN": "{{DEPLOY_DOMAIN}}",
+    "RANDOM_LABEL": "{{RANDOM_LABEL}}"
+  }
+}


### PR DESCRIPTION
This PR adds support for deploying multiple applications in a single push when using Marathon >0.13.0.

The user can specify the `--template` option multiple times to pass multiple individual templates, or use a single template which contains a list of applications.

Closes #50 