### PR TITLE
Display task info in 'show' output

### DIFF
--- a/shpkpr/commands/cmd_show.py
+++ b/shpkpr/commands/cmd_show.py
@@ -27,10 +27,16 @@ def _pretty_print(logger, application):
     logger.log("Instances:    %s", application['instances'])
     logger.log("Docker Image: %s", application['container']['docker']['image'])
     logger.log("Version:      %s", application['version'])
-    logger.log("Status:       %s", _task_status(logger, application))
+    logger.log("Status:       %s", _app_status(logger, application))
+    logger.log("")
+    logger.log("Tasks:")
+    for task in application['tasks']:
+        logger.log("- ID:   %s", task['id'])
+        for port in task['ports']:
+            logger.log("  Host: %s:%d", task['host'], port)
 
 
-def _task_status(logger, application):
+def _app_status(logger, application):
     """Returns a nicely formatted string we can use to display application health on the CLI.
     """
     if len(application['deployments']) > 0:

--- a/shpkpr/marathon/schema/app.json
+++ b/shpkpr/marathon/schema/app.json
@@ -162,6 +162,30 @@
       "minimum": 0,
       "type": "number"
     },
+    "tasks": {
+      "items": {
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "hosts": {
+            "type": "string"
+          },
+          "ports": {
+            "items": {
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
     "version": {
       "format": "date-time",
       "type": "string"
@@ -180,6 +204,7 @@
     "mem",
     "tasksRunning",
     "tasksUnhealthy",
+    "tasks",
     "version"
   ],
   "type": "object"

--- a/tests/commands/test_cmd_show.py
+++ b/tests/commands/test_cmd_show.py
@@ -1,4 +1,5 @@
 # third-party imports
+import responses
 from click.testing import CliRunner
 
 # local imports
@@ -20,3 +21,22 @@ def test_help():
     assert result.exit_code == 0
     assert 'Usage:' in result.output
     assert 'Shows detailed information for a single application.' in result.output
+
+
+@responses.activate
+def test_task_output(runner, json_fixture):
+    responses.add(responses.GET,
+                  'http://marathon.somedomain.com:8080/v2/apps/test-app',
+                  status=200,
+                  json=json_fixture("valid_app"))
+
+    result = runner(['show'], env={
+        'SHPKPR_MARATHON_URL': "http://marathon.somedomain.com:8080",
+        'SHPKPR_APPLICATION': 'test-app',
+    })
+
+    assert "ID:   test-app.4f923863-92a5-11e5-96b3-0e6bed2f38c7" in result.output
+    assert "Host: 10.210.79.53:31001" in result.output
+    assert "ID:   test-app.66c575bb-9441-11e5-8523-0a61f3a56943" in result.output
+    assert "Host: 10.210.51.111:31000" in result.output
+    assert result.exit_code == 0


### PR DESCRIPTION
This PR adds individual task information to the output of the `show` command:

```bash
paddy@laforge:~/.../shopkeep/shpkpr$ shpkpr show -a dummy-service
ID:           dummy-service
CPUs:         0.5
RAM:          512
Instances:    2
Docker Image: dummy_service:master-ab4b1022deac74b167cbc
Version:      2016-01-05T17:25:47.858Z
Status:       HEALTHY

Tasks:
- ID:   dummy-service.5c17d2e7-b3d1-11e5-a4b2-1286e9ded6ed
  Host: 10.210.37.7:31274
- ID:   dummy-service.fef0af5a-b577-11e5-a4b2-1286e9ded6ed
  Host: 10.210.29.195:31400
```

Closes #3 