### PR TITLE
Remove unique constraint on container ports

### DIFF
--- a/shpkpr/marathon/schema/deploy.json
+++ b/shpkpr/marathon/schema/deploy.json
@@ -252,8 +252,7 @@
         "minimum": 0,
         "type": "integer"
       },
-      "type": "array",
-      "uniqueItems": true
+      "type": "array"
     },
     "requirePorts": {
       "type": "boolean"


### PR DESCRIPTION
This PR removes the unique constraint on container ports. This was in the schema when originally adapted from Marathon but has since been removed. This update brings us into line with the official schema.