### PR TITLE
Added --dry-run option to deploy command

### DIFF
--- a/docs/usage/cmd_deploy.rst
+++ b/docs/usage/cmd_deploy.rst
@@ -11,6 +11,8 @@ Deploying a new application config
 
     Options:
       --force                Force update even if a deployment is in progress.
+      --dry-run              Enables dry-run mode. Shpkpr will not attempt to
+                             contact Marathon when this is enabled.
       -t, --template TEXT    Name of the template to use for deployment.
                              [required]
       --template_dir TEXT    Base directory in which your templates are stored (default: `pwd`).
@@ -48,6 +50,12 @@ Optional Configuration
     Using the force flag allows the user to initiate a deployment even if another deployment is currently in progress. This option should only be used in the case of a previous failed deployment as it *may* leave the app in an inconsistent state if anything goes wrong.
 
     * Command-line flag: ``--force``
+
+**Dry Run:**
+
+    Using the dry-run flag allows the user to test a deployment before performing it against a live Marathon instance. When enabled, shpkpr will not attempt to contact the configured Marathon server.
+
+    * Command-line flag: ``--dry-run``
 
 **Environment Variable Prefix:**
 

--- a/shpkpr/cli/options.py
+++ b/shpkpr/cli/options.py
@@ -40,6 +40,13 @@ cpus = click.option(
 )
 
 
+dry_run = click.option(
+    '--dry-run',
+    is_flag=True,
+    help='Enables dry-run mode. Shpkpr will not attempt to contact Marathon when this is enabled.',
+)
+
+
 env_prefix = click.option(
     '-e', '--env_prefix',
     'env_prefix',

--- a/shpkpr/commands/cmd_deploy.py
+++ b/shpkpr/commands/cmd_deploy.py
@@ -13,14 +13,19 @@ from shpkpr.template import render_json_template
 @click.command('deploy', short_help='Deploy application from template.', context_settings=CONTEXT_SETTINGS)
 @arguments.env_pairs
 @options.force
+@options.dry_run
 @options.template_names
 @options.template_path
 @options.env_prefix
 @options.marathon_client
 @pass_logger
-def cli(logger, marathon_client, env_prefix, template_path, template_names, force, env_pairs):
+def cli(logger, marathon_client, env_prefix, template_path, template_names, dry_run, force, env_pairs):
     """Deploy application from template.
     """
+    # set dry_run param if the user has requested it. This happens in the
+    # command callback as it only applies to the deploy command and doesn't make
+    # sense anywhere else.
+    marathon_client.dry_run = dry_run
     # read and render deploy template using values from the environment
     values = load_values_from_environment(prefix=env_prefix, overrides=env_pairs)
     rendered_templates = []

--- a/shpkpr/marathon/__init__.py
+++ b/shpkpr/marathon/__init__.py
@@ -1,5 +1,6 @@
 # local imports
 from .client import ClientError
+from .client import DryRun
 from .client import MarathonClient
 from .deployment import DeploymentFailed
 from .deployment import DeploymentNotFound
@@ -10,6 +11,7 @@ __all__ = [
     'ClientError',
     'DeploymentFailed',
     'DeploymentNotFound',
+    'DryRun',
     'MarathonClient',
     'MarathonDeployment',
 ]

--- a/shpkpr/marathon/client.py
+++ b/shpkpr/marathon/client.py
@@ -20,6 +20,10 @@ class ClientError(exceptions.ShpkprException):
     pass
 
 
+class DryRun(exceptions.ShpkprException):
+    exit_code = 0
+
+
 class MarathonClient(object):
     """A thin wrapper around marathon.MarathonClient for internal use
     """
@@ -28,11 +32,14 @@ class MarathonClient(object):
         self._marathon_url = marathon_url
         self._app_schema_path = app_schema_path
         self._deploy_schema_path = deploy_schema_path
+        self.dry_run = False
 
     def _build_url(self, path):
         return self._marathon_url.rstrip("/") + path
 
     def _make_request(self, method, path, **kwargs):
+        if self.dry_run:
+            raise DryRun("Exiting as --dry-run requested")
         request = getattr(requests, method.lower())
         return request(self._build_url(path), **kwargs)
 

--- a/tests/commands/test_cmd_deploy.py
+++ b/tests/commands/test_cmd_deploy.py
@@ -84,3 +84,31 @@ def test_multiple_templates(mock_deployment_wait, runner, json_fixture):
     result = runner(['deploy', '--template', 'tests/test.json.tmpl', '--template', 'tests/test-2.json.tmpl'], env=env)
 
     assert result.exit_code == 0
+
+
+@responses.activate
+def test_dry_run(runner, json_fixture):
+    env = {
+        'SHPKPR_MARATHON_URL': "http://marathon.somedomain.com:8080",
+        'SHPKPR_APPLICATION': 'test-app',
+        'SHPKPR_DOCKER_REPOTAG': 'goexample/outyet:latest',
+        'SHPKPR_DOCKER_EXPOSED_PORT': '8080',
+        'SHPKPR_DEPLOY_DOMAIN': 'mydomain.com',
+    }
+    result = runner(['deploy', '--dry-run', '--template', 'tests/test.json.tmpl', 'RANDOM_LABEL=some_value'], env=env)
+
+    assert result.exit_code == 0
+    assert '--dry-run' in result.output
+
+
+@responses.activate
+def test_dry_run_fail(runner, json_fixture):
+    env = {
+        'SHPKPR_MARATHON_URL': "http://marathon.somedomain.com:8080",
+        'SHPKPR_APPLICATION': 'test-app',
+        'SHPKPR_DOCKER_REPOTAG': 'goexample/outyet:latest',
+        'SHPKPR_DOCKER_EXPOSED_PORT': '8080',
+    }
+    result = runner(['deploy', '--dry-run', '--template', 'tests/test.json.tmpl', 'RANDOM_LABEL=some_value'], env=env)
+
+    assert not result.exit_code == 0

--- a/tests/marathon/test_client.py
+++ b/tests/marathon/test_client.py
@@ -10,6 +10,7 @@ import responses
 # local imports
 from shpkpr.marathon import ClientError
 from shpkpr.marathon import DeploymentNotFound
+from shpkpr.marathon import DryRun
 from shpkpr.marathon import MarathonClient
 
 
@@ -132,6 +133,14 @@ def test_deploy_conflict():
 
     client = MarathonClient("http://marathon.somedomain.com:8080")
     with pytest.raises(ClientError):
+        client.deploy({"id": "test-app"})
+
+
+@responses.activate
+def test_deploy_dry_run():
+    client = MarathonClient("http://marathon.somedomain.com:8080")
+    client.dry_run = True
+    with pytest.raises(DryRun):
         client.deploy({"id": "test-app"})
 
 


### PR DESCRIPTION
This PR adds a `--dry-run` option to the `deploy` command, allowing the user to test a deployment locally before interacting with a live Marathon instance.