### PR TITLE
bluegreen deploy fixes

### DIFF
--- a/shpkpr/commands/cmd_bluegreen.py
+++ b/shpkpr/commands/cmd_bluegreen.py
@@ -83,12 +83,7 @@ def cli(logger, marathon_client, marathon_lb_url, initial_instances, max_wait,
                                 initial_instances,
                                 marathon_lb_url)
             except (DeploymentFailed, SwapApplicationTimeout):
-                logger.log("Deployment failed: removing newly deployed stack")
-                success = marathon_client.delete_application(app['id'], force=force)
-                if success:
-                    logger.log("Successfully removed newly deployed stack: %s", app['id'])
-                else:
-                    logger.log("Unable to remove newly deployed stack, manual intervention required: %s", app['id'])
+                remove_new_stack(marathon_client, logger, app['id'], force)
 
 
 def deploy_and_swap(marathon_client, new_app, previous_deploys, logger, force,
@@ -113,3 +108,14 @@ def deploy_and_swap(marathon_client, new_app, previous_deploys, logger, force,
                                    new_app,
                                    old_app,
                                    time.time())
+
+
+def remove_new_stack(marathon_client, logger, app_id, force):
+    """Removes the newly started stack after a deploy error
+    """
+    logger.log("Deployment failed: removing newly deployed stack")
+    success = marathon_client.delete_application(app_id, force=force)
+    if success:
+        logger.log("Successfully removed newly deployed stack: %s", app_id)
+    else:
+        logger.log("Unable to remove newly deployed stack, manual intervention required: %s", app_id)

--- a/shpkpr/commands/cmd_bluegreen.py
+++ b/shpkpr/commands/cmd_bluegreen.py
@@ -29,7 +29,7 @@ class DualStackAlreadyExists(exceptions.ShpkprException):
     exit_code = 2
 
     def format_message(self):
-        msg = "Both blue and green stacks detected on Marathon, please resolve"
+        msg = "Both blue and green stacks detected on Marathon, please resolve "
         msg += "before deploying. This may mean that another deploy is in progress."
         return msg
 

--- a/shpkpr/commands/cmd_bluegreen.py
+++ b/shpkpr/commands/cmd_bluegreen.py
@@ -64,7 +64,7 @@ def cli(logger, marathon_client, marathon_lb_url, initial_instances, max_wait,
         # than one stack currently active.
         previous_deploys = fetch_previous_deploys(marathon_client, app)
         if len(previous_deploys) > 1:
-            raise DualStackAlreadyExists
+            raise DualStackAlreadyExists("Both blue and green apps detected")
         # transform the app to be deployed to apply the correct labels and
         # ID-change that will allow marathon-lb to cut traffic over as necessary.
         new_app = prepare_deploy(previous_deploys, app, initial_instances)

--- a/shpkpr/commands/cmd_bluegreen.py
+++ b/shpkpr/commands/cmd_bluegreen.py
@@ -90,7 +90,7 @@ def deploy_and_swap(marathon_client, new_app, previous_deploys, logger, force,
                     max_wait, step_interval, initial_instances, marathon_lb_url):
     """Deploy a new application and swap traffic from the old one once complete.
     """
-    marathon_client.deploy([new_app]).wait()
+    marathon_client.deploy([new_app]).wait(timeout=max_wait)
 
     if len(previous_deploys) == 0:
         # This was the first deploy, nothing to swap
@@ -119,3 +119,4 @@ def remove_new_stack(marathon_client, logger, app_id, force):
         logger.log("Successfully removed newly deployed stack: %s", app_id)
     else:
         logger.log("Unable to remove newly deployed stack, manual intervention required: %s", app_id)
+    raise DeploymentFailed("Deployment failed")

--- a/shpkpr/marathon/client.py
+++ b/shpkpr/marathon/client.py
@@ -81,11 +81,12 @@ class MarathonClient(object):
         else:
             return False
 
-    def delete_application(self, application_id):
+    def delete_application(self, application_id, force=False):
         """Deletes the Application corresponding with application_id
         """
         path = "/v2/apps/" + application_id
-        response = self._make_request('DELETE', path)
+        params = {"force": "true"} if force else {}
+        response = self._make_request('DELETE', path, params=params)
 
         if response.status_code == 200:
             return True

--- a/shpkpr/marathon_lb.py
+++ b/shpkpr/marathon_lb.py
@@ -11,6 +11,13 @@ import click
 import requests
 import six.moves.urllib as urllib
 
+# local imports
+from shpkpr import exceptions
+
+
+class SwapApplicationTimeout(exceptions.ShpkprException):
+    pass
+
 
 def _get_alias_records(hostname):
     """Return all IPv4 A records for a given hostname
@@ -173,7 +180,7 @@ def max_wait_exceeded(max_wait, timestamp):
 
 def check_time_and_sleep(max_wait, step_interval, timestamp):
     if max_wait_exceeded(max_wait, timestamp):
-        raise Exception('Max wait Time Exceeded')
+        raise SwapApplicationTimeout('Max wait Time Exceeded')
 
     return time.sleep(step_interval)
 

--- a/shpkpr/marathon_lb.py
+++ b/shpkpr/marathon_lb.py
@@ -401,22 +401,3 @@ def prepare_deploy(previous_deploys, app, initial_instances):
     app['labels']['HAPROXY_DEPLOYMENT_STARTED_AT'] = datetime.now().isoformat()
 
     return app
-
-
-def safe_resume_deploy(logger, force, max_wait, step_interval, initial_instances,
-                       marathon_client, marathon_lb_url, previous_deploys):
-    if force or click.confirm("Found previous deployment, resuming"):
-        new_app, old_app = select_last_two_deploys(previous_deploys)
-        return swap_bluegreen_apps(logger,
-                                   force,
-                                   max_wait,
-                                   step_interval,
-                                   initial_instances,
-                                   marathon_client,
-                                   marathon_lb_url,
-                                   new_app,
-                                   old_app,
-                                   time.time())
-    else:
-        raise Exception("There appears to be an"
-                        " existing deployment in progress")


### PR DESCRIPTION
This PR adds several fixes for our current bluegreen deploy method.

- Removes the `safe_resume` behaviour inherited from `bluegreen.py` as it doesn't fit our usecase and has introduced fragility/confusion.
- On a failed deploy, the newly created stack will be removed when a failure or timeout occurs, either during the initial deploy of the new app or during the swap process.

Requires some additional manual testing before merge to master. Will update this PR when that has happened.