### PR TITLE
Remove leading slash on all app names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ services:
 env:
   - TEST_TARGET=test.2.7
   - TEST_TARGET=test.3.3
-  - TEST_TARGET=test.3.4
   - TEST_TARGET=test.3.5
   - TEST_TARGET=test.pypy
 

--- a/shpkpr/marathon_lb.py
+++ b/shpkpr/marathon_lb.py
@@ -330,9 +330,6 @@ def set_app_ids(app, colour):
     app['labels']['HAPROXY_APP_ID'] = app['id']
     app['id'] = app['id'] + '-' + colour
 
-    if app['id'][0] != '/':
-        app['id'] = '/' + app['id']
-
     return app
 
 


### PR DESCRIPTION
The leading slash placed on all app names causes bluegreen deployments to Marathon groups to fail. Testing without the leading slash revealed no negative impact.

I intend to tag this as beta3 in order to unblock grouping of Shopkeep apps.