### PR TITLE
Ignore .eggs/ dir

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@ dist
 *.pyc
 *.pyo
 tests/__pycache__
+.eggs/
 .tox
 .coverage
 .git/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ build
 dist
 .cache
 *.egg-info
+.eggs
 *.pyc
 *.pyo
 tests/__pycache__


### PR DESCRIPTION
This PR ignores the `.eggs/` dir (a build artifact) from both Git and Docker.