### PR TITLE
Add cron docs link to usage index page

### DIFF
--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -28,3 +28,4 @@ For more detailed usage instructions use the sections linked below:
    cmd_list
    cmd_show
    cmd_deploy
+   cmd_cron


### PR DESCRIPTION
For some reason this was never added previously and so you can't browse to the docs for `shpkpr cron` currently, you have to know the address and type it manually. This fixes that.