### PR TITLE
blue/green deploy config cleanup and integration testing

### DIFF
--- a/shpkpr/cli/options.py
+++ b/shpkpr/cli/options.py
@@ -103,30 +103,11 @@ marathon_lb_url = click.option(
 )
 
 
-initial_instances = click.option(
-    '--initial-instances',
-    type=int,
-    help='Ammount of instances to launch before continuing deploy',
-    envvar="{0}_INITIAL_INSTANCES".format(CONTEXT_SETTINGS['auto_envvar_prefix']),
-    default=5,
-)
-
-
 max_wait = click.option(
     '--max-wait',
     'max_wait',
     type=int,
-    help='Maximum amount of time to wait for command to finish',
+    help='Maximum amount of time to wait for deployment to finish before aborting.',
     envvar="{0}_MAX_WAIT".format(CONTEXT_SETTINGS['auto_envvar_prefix']),
     default=300,
-)
-
-
-step_interval = click.option(
-    '--step-interval',
-    'step_interval',
-    type=int,
-    envvar="{0}_STEP_INTERVAL".format(CONTEXT_SETTINGS['auto_envvar_prefix']),
-    help='Time to wait between steps in command',
-    default=5,
 )

--- a/shpkpr/marathon/client.py
+++ b/shpkpr/marathon/client.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import
 
 # third-party imports
-import json
 import requests
 from cached_property import cached_property
 
@@ -66,20 +65,6 @@ class MarathonClient(object):
             self._deploy_schema_path = schema_path("deploy")
         raw_schema = read_schema_from_file(self._deploy_schema_path)
         return Schema(raw_schema)
-
-    def delete_tasks(self, task_ids, scale=True):
-        """Deletes and optionally scales apps for the task_ids given
-        """
-        path = '/v2/tasks/delete'
-        data = json.dumps({'ids': task_ids})
-        params = {'scale': scale}
-        headers = {'Content-Type': 'application/json'}
-        response = self._make_request('POST', path, headers=headers, params=params, data=data)
-
-        if response.status_code == 200:
-            return True
-        else:
-            return False
 
     def delete_application(self, application_id, force=False):
         """Deletes the Application corresponding with application_id

--- a/tests/commands/test_cmd_deploy.py
+++ b/tests/commands/test_cmd_deploy.py
@@ -97,7 +97,6 @@ def test_dry_run(runner, json_fixture):
         'SHPKPR_APPLICATION': 'test-app',
         'SHPKPR_DOCKER_REPOTAG': 'goexample/outyet:latest',
         'SHPKPR_DOCKER_EXPOSED_PORT': '8080',
-        'SHPKPR_DEPLOY_DOMAIN': 'mydomain.com',
     }
     _tmpl_path = "tests/fixtures/templates/marathon/test.json.tmpl"
     result = runner(['deploy', '--dry-run', '--template', _tmpl_path, 'RANDOM_LABEL=some_value'], env=env)
@@ -112,7 +111,6 @@ def test_dry_run_fail(runner, json_fixture):
         'SHPKPR_MARATHON_URL': "http://marathon.somedomain.com:8080",
         'SHPKPR_APPLICATION': 'test-app',
         'SHPKPR_DOCKER_REPOTAG': 'goexample/outyet:latest',
-        'SHPKPR_DOCKER_EXPOSED_PORT': '8080',
     }
     _tmpl_path = "tests/fixtures/templates/marathon/test.json.tmpl"
     result = runner(['deploy', '--dry-run', '--template', _tmpl_path, 'RANDOM_LABEL=some_value'], env=env)

--- a/tests/fixtures/templates/marathon/test-bluegreen.json.tmpl
+++ b/tests/fixtures/templates/marathon/test-bluegreen.json.tmpl
@@ -1,19 +1,19 @@
 {
-  "id": "{{APPLICATION}}",
+  "id": "{{APPLICATION}}-bluegreen",
   "cpus": 0.1,
-  "mem": 512,
-  "instances": 1,
+  "mem": 256,
+  "instances": 4,
   "container": {
     "type": "DOCKER",
     "docker": {
       "image": "{{DOCKER_REPOTAG}}",
-      "forcePullImage": false,
       "network": "BRIDGE",
       "portMappings": [
         {
           "containerPort": {{DOCKER_EXPOSED_PORT}},
           "hostPort": 0,
-          "protocol": "tcp"
+          "protocol": "tcp",
+          "servicePort": 11090
         }
       ]
     }
@@ -30,19 +30,16 @@
     }
   ],
   "constraints": [
-    [
-      "hostname",
-      "UNIQUE"
-    ],
-    [
-      "subnet", "LIKE", "internal"
-    ]
+    ["hostname", "UNIQUE"]
   ],
   "upgradeStrategy": {
       "minimumHealthCapacity": 1,
       "maximumOverCapacity": 1
   },
   "labels": {
-    "RANDOM_LABEL": "{{RANDOM_LABEL}}"
+      "HAPROXY_DEPLOYMENT_GROUP": "{{DEPLOYMENT_GROUP}}",
+      "HAPROXY_GROUP": "internal",
+      "HAPROXY_DEPLOYMENT_ALT_PORT": "11091",
+      "HAPROXY_0_VHOST": "{{DEPLOY_DOMAIN}}"
   }
 }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,7 +16,9 @@ def env():
     # that they're set appropriately
     env = {
         "SHPKPR_MARATHON_URL": os.environ.get("SHPKPR_MARATHON_URL", None),
+        "SHPKPR_MARATHON_LB_URL": os.environ.get("SHPKPR_MARATHON_LB_URL", None),
         "SHPKPR_APPLICATION": os.environ.get("SHPKPR_APPLICATION", None),
+        "SHPKPR_DEPLOYMENT_GROUP": os.environ.get("SHPKPR_DEPLOYMENT_GROUP", None),
         "SHPKPR_DOCKER_REPOTAG": os.environ.get("SHPKPR_DOCKER_REPOTAG", None),
         "SHPKPR_DOCKER_EXPOSED_PORT": os.environ.get("SHPKPR_DOCKER_EXPOSED_PORT", None),
         "SHPKPR_DEPLOY_DOMAIN": os.environ.get("SHPKPR_DEPLOY_DOMAIN", None),

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -97,3 +97,31 @@ def test_cron_show_after_delete(runner, env):
 
     _check_output_does_not_contain(result, '"name": "shpkpr-test-job"')
     _check_exits_zero(result)
+
+
+@pytest.mark.integration
+def test_bluegreen_deploy(runner, env):
+    _tmpl_path = "tests/fixtures/templates/marathon/test-bluegreen.json.tmpl"
+    result = runner(["bluegreen", "-t", _tmpl_path, "--force"], env=env)
+    _check_exits_zero(result)
+
+
+@pytest.mark.integration
+def test_ensure_bluegreen_deployed(runner, env):
+    result = runner(["list"], env=env)
+    _check_exits_zero(result)
+    _check_output_contains(result, env['SHPKPR_APPLICATION'] + "-bluegreen-blue")
+
+
+@pytest.mark.integration
+def test_bluegreen_deploy_with_existing_app(runner, env):
+    _tmpl_path = "tests/fixtures/templates/marathon/test-bluegreen.json.tmpl"
+    result = runner(["bluegreen", "-t", _tmpl_path, "--force"], env=env)
+    _check_exits_zero(result)
+
+
+@pytest.mark.integration
+def test_ensure_bluegreen_swapped(runner, env):
+    result = runner(["list"], env=env)
+    _check_exits_zero(result)
+    _check_output_contains(result, env['SHPKPR_APPLICATION'] + "-bluegreen-green")

--- a/tests/marathon/test_client.py
+++ b/tests/marathon/test_client.py
@@ -179,13 +179,3 @@ def test_get_deployment_not_found():
     client = MarathonClient("http://marathon.somedomain.com:8080")
     with pytest.raises(DeploymentNotFound):
         client.get_deployment("1234")
-
-
-@mock.patch('requests.post')
-def test_delete_tasks(requests):
-    client = MarathonClient("http://marathon.somedomain.com:8080")
-    client.delete_tasks(['foo', 'bar'], scale=True)
-    requests.assert_called_with('http://marathon.somedomain.com:8080/v2/tasks/delete',
-                                data='{"ids": ["foo", "bar"]}',
-                                headers={'Content-Type': 'application/json'},
-                                params={'scale': True},)

--- a/tox.ini
+++ b/tox.ini
@@ -17,10 +17,5 @@ commands = {env:TOXBUILD:py.test -vv --pep8 --flakes --mccabe --cov={envsitepack
 [testenv:integration]
 passenv =
           LANG
-          SHPKPR_APPLICATION
-          SHPKPR_DEPLOY_DOMAIN
-          SHPKPR_DOCKER_EXPOSED_PORT
-          SHPKPR_DOCKER_REPOTAG
-          SHPKPR_MARATHON_URL
-          SHPKPR_CHRONOS_URL
+          SHPKPR_*
 commands = py.test -vv -x -m 'integration'


### PR DESCRIPTION
This PR removes two config values from the `bluegreen` command (they weren't used ever) and adds an integration test for bluegreen deployment.