### PR TITLE
Integrate pytest with setup.py directly rather than tox

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
+[aliases]
+test=pytest
+
 [bdist_wheel]
 universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,35 +1,11 @@
 # stdlib imports
-import sys
 from setuptools import setup
-from setuptools.command.test import test as TestCommand
 
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()
 
 
-class Tox(TestCommand):
-
-    user_options = [('tox-args=', 'a', "Arguments to pass to tox")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.tox_args = None
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        # import here, because outside the eggs aren't loaded
-        import tox
-        import shlex
-        args = self.tox_args
-        if args:
-            args = shlex.split(self.tox_args)
-        errno = tox.cmdline(args=args)
-        sys.exit(errno)
 
 
 setup(
@@ -72,6 +48,12 @@ setup(
         [console_scripts]
         shpkpr=shpkpr.cli.entrypoint:cli
     ''',
-    tests_require=['tox'],
-    cmdclass={'test': Tox},
+    setup_requires=[
+        'pytest-runner',
+    ],
+    tests_require=[
+        'mock',
+        'pytest',
+        'responses',
+    ],
 )

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,3 +1,6 @@
+# stdlib imports
+import copy
+
 # third-party imports
 import pytest
 
@@ -105,9 +108,12 @@ def test_bluegreen_deploy(runner, env):
 
 @pytest.mark.integration
 def test_ensure_bluegreen_deployed(runner, env):
-    result = runner(["list"], env=env)
+    local_env = copy.deepcopy(env)
+    local_env["SHPKPR_APPLICATION"] = "shpkpr-test/integration-test-bluegreen-blue"
+
+    result = runner(["show"], env=local_env)
     _check_exits_zero(result)
-    _check_output_contains(result, env['SHPKPR_APPLICATION'] + "-bluegreen-blue")
+    _check_output_contains(result, "shpkpr-test/integration-test-bluegreen-blue")
 
 
 @pytest.mark.integration
@@ -119,6 +125,9 @@ def test_bluegreen_deploy_with_existing_app(runner, env):
 
 @pytest.mark.integration
 def test_ensure_bluegreen_swapped(runner, env):
-    result = runner(["list"], env=env)
+    local_env = copy.deepcopy(env)
+    local_env["SHPKPR_APPLICATION"] = "shpkpr-test/integration-test-bluegreen-green"
+
+    result = runner(["show"], env=local_env)
     _check_exits_zero(result)
-    _check_output_contains(result, env['SHPKPR_APPLICATION'] + "-bluegreen-green")
+    _check_output_contains(result, "shpkpr-test/integration-test-bluegreen-green")

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py27, py33, py34, py35, py36, pypy
 skipsdist = {env:TOXBUILD:false}
 
 [pytest]
+addopts = -m 'not integration'
 pep8maxlinelength = 119
 testpaths = shpkpr tests
 


### PR DESCRIPTION
This PR integrates pytest directly with setup.py.

Previously tox was integrated directly with setup.py but that never really made sense IMO. tox is a higher level tool and `python setup.py test` should always just run the app's tests in the current environment.

TODO:

- [x] Ensure integration tests still run