### PR TITLE
Ensure lowest requirement versions are tested by tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: python
+
+env:
+  - REQUIREMENTS=lowest
+  - REQUIREMENTS=current
+
 python:
 - "2.7"
 - "3.3"
@@ -10,7 +15,7 @@ python:
 install:
 - pip install tox
 script:
-- tox -e $(echo py$TRAVIS_PYTHON_VERSION | tr -d . | sed -e 's/pypypy/pypy/')
+- tox -e $(echo py$TRAVIS_PYTHON_VERSION | tr -d . | sed -e 's/pypypy/pypy/')-$REQUIREMENTS
 
 notifications:
   email: false

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,7 @@
-FROM themattrix/tox
+FROM themattrix/tox-base
+
+COPY requirements-test.txt setup.py tox.ini /app/
+RUN bash -c "TOXBUILD=true tox"
 
 RUN chown -R tox:tox /app/
 COPY docker-entrypoint.sh /

--- a/Makefile
+++ b/Makefile
@@ -24,22 +24,22 @@ test: clean build-test ## Run tests against all supported Python versions (2.7, 
 	$(call docker-test)
 
 test.2.7: clean build-test ## Run Python 2.7 tests inside Docker
-	$(call docker-test,,tox -e py27)
+	$(call docker-test,,tox -e py27-lowest -e py27-current)
 
 test.3.3: clean build-test ## Run Python 3.3 tests inside Docker
-	$(call docker-test,,tox -e py33)
+	$(call docker-test,,tox -e py33-lowest -e py33-current)
 
 test.3.4: clean build-test ## Run Python 3.4 tests inside Docker
-	$(call docker-test,,tox -e py34)
+	$(call docker-test,,tox -e py34-lowest -e py34-current)
 
 test.3.5: clean build-test ## Run Python 3.5 tests inside Docker
-	$(call docker-test,,tox -e py35)
+	$(call docker-test,,tox -e py35-lowest -e py35-current)
 
 test.3.6: clean build-test ## Run Python 3.6 tests inside Docker
-	$(call docker-test,,tox -e py36)
+	$(call docker-test,,tox -e py36-lowest -e py36-current)
 
 test.pypy: clean build-test ## Run PyPy 2 tests inside Docker
-	$(call docker-test,,tox -e pypy)
+	$(call docker-test,,tox -e pypy-lowest,pypy-current)
 
 test.integration: clean build-test ## Run integration tests inside Docker
 	$(shell env | grep SHPKPR > .env.integration)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-# shpkpr requirements
-
-cached-property==1.3.0
-chronos-python==1.0.0
-click==6.0
-Jinja2==2.8
-jsonschema==2.6.0
-requests==2.9.0
-six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,16 @@
 from setuptools import setup
 
 
-with open('README.rst') as readme_file:
-    readme = readme_file.read()
+try:
+    with open('README.rst') as readme_file:
+        readme = readme_file.read()
+except IOError:
+    # README is not always available at the time this file is imported. This
+    # really only applies during an initial container build when we copy in
+    # setup.py but not the README. This is mostly to help with caching and
+    # keeping the time required to run the tests to a minimum. This should never
+    # make it into an actual build or release package.
+    readme = "Not Available"
 
 
 
@@ -25,12 +33,12 @@ setup(
         'click>=6.0, <7',
         'jinja2>=2.6, <3',
         'jsonschema>=2.6, <3',
-        'six>=1, <2',
-        'requests>=2, <3',
+        'six>=1.7.0',
+        'requests>=2.4.2',
     ],
     license='MIT',
     zip_safe=False,
-    keywords='shpkpr mesos marathon',
+    keywords='shpkpr mesos marathon chronos',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
@@ -43,6 +51,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     entry_points='''
         [console_scripts]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, pypy
+envlist = py{27,33,34,35,36,py}-{lowest,current}
 skipsdist = {env:TOXBUILD:false}
 
 [pytest]
@@ -11,12 +11,17 @@ testpaths = shpkpr tests
 passenv = LANG
 whitelist_externals = true
 deps =
-    -r{toxinidir}/requirements.txt
+    requirements-builder
     -r{toxinidir}/requirements-test.txt
-commands = {env:TOXBUILD:py.test -vv --pep8 --flakes --mccabe --cov={envsitepackagesdir}/shpkpr --cov-report=term-missing -m 'not integration'}
+commands =
+    lowest: requirements-builder --level=min -o .tox/lowest.txt setup.py
+    lowest: pip install -r .tox/lowest.txt
+    current: requirements-builder --level=pypi -o .tox/current.txt setup.py
+    current: pip install -r .tox/current.txt
+    {env:TOXBUILD:py.test -vv --pep8 --flakes --mccabe --cov={envsitepackagesdir}/shpkpr --cov-report=term-missing -m 'not integration'}
 
 [testenv:integration]
 passenv =
-          LANG
-          SHPKPR_*
+    LANG
+    SHPKPR_*
 commands = py.test -vv -x -m 'integration'


### PR DESCRIPTION
This PR adds additional test environments to ensure that the lowest allowed versions are tested during a CI run (and locally when using docker).