### PR TITLE
Add Docker Host Port:

### DIFF
--- a/shpkpr/resources/templates/marathon/default/standard.json.tmpl
+++ b/shpkpr/resources/templates/marathon/default/standard.json.tmpl
@@ -118,7 +118,7 @@
                         Setting `hostPort` to `0` allows Marathon to dynamically
                         allocate a port on the host to map.
                     #}
-                    "hostPort": 0,
+                    "hostPort": {{DOCKER_HOST_PORT|default(0)}},
                     "protocol": "tcp"
                 }
             ],


### PR DESCRIPTION
This adds DOCKER_HOST_PORT to the default marathon template which will allow a custom port to be specified. I plan to use it for tcp apps that don't use marathon-lb. I will be using consul for service discovery which needs a static port for apps to use.