### PR TITLE
Update default health check protocol

### DIFF
--- a/shpkpr/resources/templates/marathon/default/bluegreen.json.tmpl
+++ b/shpkpr/resources/templates/marathon/default/bluegreen.json.tmpl
@@ -46,7 +46,7 @@
 "healthChecks": [
     {
         "path": "{{MARATHON_HEALTH_CHECK_PATH}}",
-        "protocol": "{{MARATHON_HEALTH_CHECK_PROTOCOL|default("HTTP")}}",
+        "protocol": "{{MARATHON_HEALTH_CHECK_PROTOCOL|default("MESOS_HTTP")}}",
         "portIndex": 0,
         "gracePeriodSeconds": {{MARATHON_HEALTH_CHECK_GRACE_PERIOD_SECONDS|default(300)|require_int(min=0)}},
         "intervalSeconds": {{MARATHON_HEALTH_CHECK_INTERVAL_SECONDS|default(10)|require_int(min=0)}},

--- a/shpkpr/resources/templates/marathon/default/standard.json.tmpl
+++ b/shpkpr/resources/templates/marathon/default/standard.json.tmpl
@@ -233,10 +233,10 @@
             #}
             "path": "{{MARATHON_HEALTH_CHECK_PATH}}",
             {#
-                Protocol of the requests to be performed. One of “HTTP”,
-                “HTTPS”, “TCP”, or “Command”.
+                Protocol of the requests to be performed. One of “MESOS_HTTP”,
+                “MESOS_HTTPS”, “MESOS_TCP”, or “Command”.
             #}
-            "protocol": "{{MARATHON_HEALTH_CHECK_PROTOCOL|default("HTTP")}}",
+            "protocol": "{{MARATHON_HEALTH_CHECK_PROTOCOL|default("MESOS_HTTP")}}",
             {#
                 A port index of `0` tells Marathon to make requests to the
                 application on the first exposed port. In this case, since the


### PR DESCRIPTION
"MESOS_HTTP", "MESOS_HTTPS" and "MESOS_TCP" are now the recommended health check protocols. This allows health checks to be run by the agent instead of the Marathon master. This can help to reduce load on it.

https://mesosphere.github.io/marathon/docs/health-checks.html#marathon-level-health-checks