### PR TITLE
Use MAX_PER instead of GROUP_BY for constraining applications

### DIFF
--- a/shpkpr/resources/templates/marathon/default/standard.json.tmpl
+++ b/shpkpr/resources/templates/marathon/default/standard.json.tmpl
@@ -185,7 +185,7 @@
         Docs: https://mesosphere.github.io/marathon/docs/constraints.html
     #}
     "constraints": [
-        ["hostname", "GROUP_BY", "{{MARATHON_GROUP_BY|default(2)|require_int(min=1)}}"]
+        ["hostname", "MAX_PER", "{{MARATHON_GROUP_BY|default(2)|require_int(min=1)}}"]
     ],
     {#
         During an upgrade all instances of an application get replaced by a new


### PR DESCRIPTION
This PR switches the default deploy template to use `MAX_PER` instead of `GROUP_BY` when defining constraints. It seems something changed in Marathon and `GROUP_BY` no longer has the effect it used to.

Decided to leave the var name as `MARATHON_GROUP_BY` for now so applications retain the desired behaviour after the change.